### PR TITLE
Add user_aliases to the options for deleting users

### DIFF
--- a/_docs/_developer_guide/rest_api/user_data.md
+++ b/_docs/_developer_guide/rest_api/user_data.md
@@ -377,7 +377,7 @@ The segmentation tool will include these users regardless of whether they have e
 Deleting user profiles CANNOT be undone. It will PERMANENTLY remove users which may cause discrepancies in your data.
 {% endalert %}
 
-This endpoint allows you to delete any user profile by specifying their external identifier (User ID). Up to 50 `external_ids` or `braze_ids` can be included in a single request. Only one of `external_ids` or `braze_ids` can be included in a single request. Please note that their associated event data will still exist in the dashboard after you delete the user.
+This endpoint allows you to delete any user profile by specifying a known user identifier. Up to 50 `external_ids`, `user_aliases`, or `braze_ids` can be included in a single request. Only one of `external_ids`, `user_aliases`, or `braze_ids` can be included in a single request. Please note that users' associated event data will still exist in the dashboard after you delete the user(s).
 
 Your Endpoint will correspond to your [Braze Instance][1].
 
@@ -399,6 +399,7 @@ Content-Type: application/json
 {
   "api_key" : (required, string) App Group REST API Key,
   "external_ids" : (optional, array of string) external ids for the users to delete,
+  "user_aliases" : (optional, array of User Alias objects) User Aliases for the users to delete,
   "braze_ids" : (optional, array of string) Braze User Identifiers for the users to delete
 }
 ```


### PR DESCRIPTION
# Pull Request/Issue Resolution

**Description of Change:**

Adding documentation to show customers that they can delete users by specifying an array of user alias objects in the `user_aliases` key.

**Reason for Change:**

This change was implemented quietly last sprint.

This functionality is live, so this can be merged at any time.


---
---

## PR Checklist
- [ ] Ensure you have completed our CLA.
- [ ] Tag @EmilyNecciai as a reviewer when the your work is done and ready to be reviewed for merge. 
- [ ] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide) to be sure you're utilizing the proper markdown formatting.
- [ ] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices) to be sure you're aligning with our voice and other style best practices.
- [ ] [Preview your deployed changes](https://homeslice.braze.com/docs) to confirm that none of your changes break production. Pay close attention to links and images.
- [ ] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
