### PR TITLE
Add 'dispatch_id' to Currents documentation for email events across all connectors

### DIFF
--- a/_docs/_partners/braze_currents/data_storage_events/message_engagement_events.md
+++ b/_docs/_partners/braze_currents/data_storage_events/message_engagement_events.md
@@ -132,6 +132,7 @@ Please note that the `Unsubscribe` event is actually a specialized click event t
   "canvas_variation_id": (string) id of the Canvas variation the user is in if from a Canvas,
   "canvas_step_id": (string) id of the step for this message if from a Canvas,
   "send_id": (string) id of the message if specified for the campaign (See Send Identifier under REST API Parameter Definitions),
+  "dispatch_id": (string) id of the message dispatch (unique id for each 'transmission' sent from the Braze platform). Users who are sent a schedule message get the same dispatch_id. Action-based or API triggered messages get a unique dispatch_id per user.,
   "email_address": (string) email address for this event,
   "url": (string) the url that was clicked (Email Click events only),
   "sending_ip": (string) the IP address from which the message was sent (Email Delivery, Bounce, and SoftBounce events only),

--- a/_docs/_partners/technology_partners/data_and_infrastructure_agility/customer_data_platform/segment_for_currents.md
+++ b/_docs/_partners/technology_partners/data_and_infrastructure_agility/customer_data_platform/segment_for_currents.md
@@ -57,6 +57,7 @@ The following properties will be included with all Braze events sent to Segment:
 | Property Name          | Type     | Description                                                                                                    |
 | `app_id`               | `String` | The API Identifier of the App on which a user received a message or performed an action, if applicable.        |
 | `send_id`              | `String` | The id of the message if specified for the campaign, if applicable.                                            |
+| `dispatch_id`          | `String` | The id of the message dispatch (unique id for each 'transmission' sent from the Braze platform). Users who are sent a schedule message get the same dispatch_id. Action-based or API triggered messages get a unique dispatch_id per user. |
 | `campaign_id`          | `String` | The API Identifier of the Campaign associated with the event, if applicable.                                   |
 | `campaign_name`        | `String` | The name of the Campaign associated with the event, if applicable.                                             |
 | `message_variation_id` | `String` | The API Identifier of the Message Variation for the Campaign associated with the event, if applicable.         |

--- a/_docs/_partners/technology_partners/insights/behavioral_analytics/amplitude_for_currents.md
+++ b/_docs/_partners/technology_partners/insights/behavioral_analytics/amplitude_for_currents.md
@@ -216,6 +216,7 @@ Devices should not report more than 60 events/second under normal circumstances,
   "canvas_variation_id": (string) id of the canvas variation the user is in if from a Canvas,
   "canvas_step_id": (string) id of the step for this message if from a Canvas,
   "send_id": (string) id of the message if specified for the campaign (See Send Identifier under REST API Parameter Definitions),
+  "dispatch_id": (string) id of the message dispatch (unique id for each 'transmission' sent from the Braze platform). Users who are sent a schedule message get the same dispatch_id. Action-based or API triggered messages get a unique dispatch_id per user.,
   "email_address": (string) email address for this event,
   "url": (string) the URL that was clicked (Email Click events only)
 }

--- a/_docs/_partners/technology_partners/insights/behavioral_analytics/mixpanel_for_currents.md
+++ b/_docs/_partners/technology_partners/insights/behavioral_analytics/mixpanel_for_currents.md
@@ -201,6 +201,7 @@ You can manage the Mixpanel Cohort Import process from the Technology Partners p
   "canvas_variation_id": (string) id of the canvas variation the user is in if from a Canvas,
   "canvas_step_id": (string) id of the step for this message if from a Canvas,
   "send_id": (string) id of the message if specified for the campaign (See Send Identifier under REST API Parameter Definitions),
+  "dispatch_id": (string) id of the message dispatch (unique id for each 'transmission' sent from the Braze platform). Users who are sent a schedule message get the same dispatch_id. Action-based or API triggered messages get a unique dispatch_id per user.,
   "email_address": (string) email address for this event,
   "url": (string) the URL that was clicked (Email Click events only)
 }


### PR DESCRIPTION
# Pull Request/Issue Resolution

**Description of Change:**

We're adding `dispatch_id` as a field on email events for all Currents connectors. This update to the docs represents that change.

This can be merged with the next weekly deploy.


---
---

## PR Checklist
- [ ] Ensure you have completed our CLA.
- [ ] Tag @EmilyNecciai as a reviewer when the your work is done and ready to be reviewed for merge. 
- [ ] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide) to be sure you're utilizing the proper markdown formatting.
- [ ] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices) to be sure you're aligning with our voice and other style best practices.
- [ ] [Preview your deployed changes](https://homeslice.braze.com/docs) to confirm that none of your changes break production. Pay close attention to links and images.
- [ ] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
