### PR TITLE
Removed https:// protocol from sdk endpoints

### DIFF
--- a/_docs/_user_guide/administrative/access_braze/sdk_endpoints.md
+++ b/_docs/_user_guide/administrative/access_braze/sdk_endpoints.md
@@ -8,12 +8,12 @@ If your company was set up with a custom endpoint, please reach out to your Cust
 
 |Instance | SDK Endpoint
 |---|---|
-|US-01 | https://sdk.iad-01.braze.com |
-|US-02 | https://sdk.iad-02.braze.com |
-|US-03 | https://sdk.iad-03.braze.com |
-|US-04 | https://sdk.iad-04.braze.com |
-|US-06 | https://sdk.iad-06.braze.com |
-|EU-01 | http://sdk.fra-01.braze.eu |
+|US-01 | sdk.iad-01.braze.com |
+|US-02 | sdk.iad-02.braze.com |
+|US-03 | sdk.iad-03.braze.com |
+|US-04 | sdk.iad-04.braze.com |
+|US-06 | sdk.iad-06.braze.com |
+|EU-01 | sdk.fra-01.braze.eu |
 
 ## Software Development Kit (SDK) File Sizes
 


### PR DESCRIPTION

# Pull Request/Issue Resolution

**Description of Change:**
I've had instances where clients have included the full value "https://sda.fra-01.braze.eu" in their appboy.xml config file which has caused their integration to break as the SDK uses https by default so actually the sdk is sending "https://https://sda.fra-01.braze.eu". Removing this will make it clearer to developers that they should not include "https://" in their config.

**Reason for Change:**
Less confusing for developers.

Closes #**ISSUE_NUMBER_HERE**


---
---

## PR Checklist
- [ ] Ensure you have completed our CLA.
- [ ] Tag @EmilyNecciai as a reviewer when the your work is done and ready to be reviewed for merge. 
- [ ] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide) to be sure you're utilizing the proper markdown formatting.
- [ ] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices) to be sure you're aligning with our voice and other style best practices.
- [ ] [Preview your deployed changes](https://homeslice.braze.com/docs) to confirm that none of your changes break production. Pay close attention to links and images.
- [ ] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
