### PR TITLE
iOS Docs - Override default images for NF and Content Cards

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/ios/content_cards/customization.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/content_cards/customization.md
@@ -32,9 +32,10 @@ For examples of these view controllers, check out our [Content Cards sample app]
 
 {{site.data.alerts.note}} To customize the header, set the title property of the `navigationItem` belonging to the `ABKContentCardsTableViewController` instance embedded in the parent `ABKContentCardsViewController` instance. {{site.data.alerts.end}}
 
-## Overriding Default Images in Content Cards
+## Overriding Default Images
 
-Braze allows clients to replace existing default images with their own custom images. To accomplish this, create a new `png` file with the custom image and add it to the app’s image bundle. To override the default placeholder image displayed when a user has a poor connection, name your custom image `appboy_cc_noimage_lrg`.
+Braze allows clients to replace existing default images with their own custom images. To accomplish this, create a new `png` file with the custom image and add it to the app’s image bundle. Then, rename the file with the image’s name (see below) to override the default image in our library. Images available for override in Content Cards include:
+* Placeholder image: `appboy_cc_noimage_lrg`.
 
 {{site.data.alerts.note}} Be sure to upload the `@2x` and `@3x` versions of the images as well to accommodate different phone sizes. {{site.data.alerts.end}}
 

--- a/_docs/_developer_guide/platform_integration_guides/ios/content_cards/customization.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/content_cards/customization.md
@@ -18,7 +18,7 @@ ABKContentCardsTableViewController *contentCards = [ABKContentCardsTableViewCont
 [self.navigationController pushViewController:contentCards animated:YES];
 ```
 
-{{site.data.alerts.note}} To customize the navigation bar's title, set the title property of the `ABKContentCardsTableViewController` instance's `navigationItem`. {{site.data.alerts.end}}
+{% alert note %} To customize the navigation bar's title, set the title property of the `ABKContentCardsTableViewController` instance's `navigationItem`. {% endalert %}
 
 ### Modal Context
 

--- a/_docs/_developer_guide/platform_integration_guides/ios/content_cards/customization.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/content_cards/customization.md
@@ -18,7 +18,7 @@ ABKContentCardsTableViewController *contentCards = [ABKContentCardsTableViewCont
 [self.navigationController pushViewController:contentCards animated:YES];
 ```
 
-{% alert note %} To customize the navigation bar's title, set the title property of the `ABKContentCardsTableViewController` instance's `navigationItem`. {% endalert %}
+{{site.data.alerts.note}} To customize the navigation bar's title, set the title property of the `ABKContentCardsTableViewController` instance's `navigationItem`. {{site.data.alerts.end}}
 
 ### Modal Context
 
@@ -37,7 +37,7 @@ For examples of these view controllers, check out our [Content Cards sample app]
 Braze allows clients to replace existing default images with their own custom images. To accomplish this, create a new `png` file with the custom image and add it to the app’s image bundle. Then, rename the file with the image’s name (see below) to override the default image in our library. Images available for override in Content Cards include:
 * Placeholder image: `appboy_cc_noimage_lrg`.
 
-{{site.data.alerts.note}} Be sure to upload the `@2x` and `@3x` versions of the images as well to accommodate different phone sizes. {{site.data.alerts.end}}
+{% alert note %} Be sure to upload the `@2x` and `@3x` versions of the images as well to accommodate different phone sizes. {% endalert %}
 
 ## Customizing the Content Cards Feed
 

--- a/_docs/_developer_guide/platform_integration_guides/ios/content_cards/customization.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/content_cards/customization.md
@@ -32,6 +32,12 @@ For examples of these view controllers, check out our [Content Cards sample app]
 
 {{site.data.alerts.note}} To customize the header, set the title property of the `navigationItem` belonging to the `ABKContentCardsTableViewController` instance embedded in the parent `ABKContentCardsViewController` instance. {{site.data.alerts.end}}
 
+## Overriding Default Images in Content Cards
+
+Braze allows clients to replace existing default images with their own custom images. To accomplish this, create a new `png` file with the custom image and add it to the app’s image bundle. To override the default placeholder image displayed when a user has a poor connection, name your custom image `appboy_cc_noimage_lrg`.
+
+{{site.data.alerts.note}} Be sure to upload the `@2x` and `@3x` versions of the images as well to accommodate different phone sizes. {{site.data.alerts.end}}
+
 ## Customizing the Content Cards Feed
 
 You can create your own Content Cards interface by extending `ABKContentCardsTableViewController` to customize all UI elements and Content Cards behavior. Alternatively, you can create a completely custom view controller and subscribe for data updates. In the latter case, you would need to log all view events, dismissed events, and clicks manually.

--- a/_docs/_developer_guide/platform_integration_guides/ios/news_feed/customizing_the_news_feed.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/news_feed/customizing_the_news_feed.md
@@ -1,11 +1,21 @@
 ---
-nav_title: Customizing the News Feed
+nav_title: Customization
 platform: iOS
 page_order: 5
 search_rank: 5
 ---
 
-# Customizing the News Feed
+# Customization
+
+## Overriding Default Images in the News Feed
+
+Braze allows clients to replace existing default images with their own custom images. To accomplish this, create a new. `png` file with the custom image and add it to the app’s image bundle. Then, rename the file with the image’s name (see below) to override the default image in our library. The image names for the Read icon and Placeholder image for News Feed are:
+* Read icon indicator: “Icons_Read"
+* Placeholder image: "img-noimage-lrg"
+
+{{site.data.alerts.note}} Be sure to upload the `@2x` and `@3x` versions of the images as well to accommodate different phone sizes. {{site.data.alerts.end}}
+
+## Creating a Custom News Feed
 
 You can create your own News Feed interface by extending `ABKNewsFeedTableViewController`. You can customize all UI elements and News Feed behavior in this way.
 

--- a/_docs/_developer_guide/platform_integration_guides/ios/news_feed/customizing_the_news_feed.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/news_feed/customizing_the_news_feed.md
@@ -7,11 +7,11 @@ search_rank: 5
 
 # Customization
 
-## Overriding Default Images in the News Feed
+## Overriding Default Images
 
-Braze allows clients to replace existing default images with their own custom images. To accomplish this, create a new `png` file with the custom image and add it to the app’s image bundle. Then, rename the file with the image’s name (see below) to override the default image in our library. The image names for the Read icon and Placeholder image (when a user has a poor connection) for News Feed are:
-* Read icon indicator: “Icons_Read"
-* Placeholder image: "img-noimage-lrg"
+Braze allows clients to replace existing default images with their own custom images. To accomplish this, create a new `png` file with the custom image and add it to the app’s image bundle. Then, rename the file with the image’s name (see below) to override the default image in our library. Images available for override in the News Feed include:
+* Read icon indicator: `Icons_Read`
+* Placeholder image: `img-noimage-lrg`
 
 {{site.data.alerts.note}} Be sure to upload the `@2x` and `@3x` versions of the images as well to accommodate different phone sizes. {{site.data.alerts.end}}
 

--- a/_docs/_developer_guide/platform_integration_guides/ios/news_feed/customizing_the_news_feed.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/news_feed/customizing_the_news_feed.md
@@ -13,7 +13,7 @@ Braze allows clients to replace existing default images with their own custom im
 * Read icon indicator: `Icons_Read`
 * Placeholder image: `img-noimage-lrg`
 
-{{site.data.alerts.note}} Be sure to upload the `@2x` and `@3x` versions of the images as well to accommodate different phone sizes. {{site.data.alerts.end}}
+{% alert note %} Be sure to upload the `@2x` and `@3x` versions of the images as well to accommodate different phone sizes. {% endalert %}
 
 ## Creating a Custom News Feed
 

--- a/_docs/_developer_guide/platform_integration_guides/ios/news_feed/customizing_the_news_feed.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/news_feed/customizing_the_news_feed.md
@@ -9,7 +9,7 @@ search_rank: 5
 
 ## Overriding Default Images in the News Feed
 
-Braze allows clients to replace existing default images with their own custom images. To accomplish this, create a new. `png` file with the custom image and add it to the app’s image bundle. Then, rename the file with the image’s name (see below) to override the default image in our library. The image names for the Read icon and Placeholder image for News Feed are:
+Braze allows clients to replace existing default images with their own custom images. To accomplish this, create a new `png` file with the custom image and add it to the app’s image bundle. Then, rename the file with the image’s name (see below) to override the default image in our library. The image names for the Read icon and Placeholder image (when a user has a poor connection) for News Feed are:
 * Read icon indicator: “Icons_Read"
 * Placeholder image: "img-noimage-lrg"
 


### PR DESCRIPTION
# Pull Request/Issue Resolution
https://jira.braze.com/browse/PC-942

**Description of Change:**
Documentation for how to override our default images for News Feed's "read" indicator and placeholder (empty) image. Also, added docs for the placeholder image in Content Cards

**Reason for Change:**

Closes #**ISSUE_NUMBER_HERE**


---
---

## PR Checklist
- [ ] Ensure you have completed our CLA.
- [ ] Tag @EmilyNecciai as a reviewer when the your work is done and ready to be reviewed for merge. 
- [ ] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide) to be sure you're utilizing the proper markdown formatting.
- [ ] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices) to be sure you're aligning with our voice and other style best practices.
- [ ] [Preview your deployed changes](https://homeslice.braze.com/docs) to confirm that none of your changes break production. Pay close attention to links and images.
- [ ] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
