### PR TITLE
Add swift code to Content Cards Customization page

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/ios/content_cards/customization.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/content_cards/customization.md
@@ -18,6 +18,8 @@ Example of pushing a `ABKContentCardsTableViewController` instance into a naviga
 
 ```objc
 ABKContentCardsTableViewController *contentCards = [ABKContentCardsTableViewController getNavigationFeedViewController];
+contentCards.title = "Content Cards Title";
+contentCards.disableUnreadIndicator = YES;
 [self.navigationController pushViewController:contentCards animated:YES];
 ```
 
@@ -26,7 +28,7 @@ ABKContentCardsTableViewController *contentCards = [ABKContentCardsTableViewCont
 
 ```swift
 let contentCards = ABKContentCardsTableViewController()
-contentCards.title = "TVC Title"
+contentCards.title = "Content Cards Title"
 contentCards.disableUnreadIndicator = true
 navigationController?.pushViewController(contentCards, animated: true)
 ```
@@ -34,7 +36,9 @@ navigationController?.pushViewController(contentCards, animated: true)
 {% endtab %}
 {% endtabs %}
 
-{{site.data.alerts.note}} To customize the navigation bar's title, set the title property of the `ABKContentCardsTableViewController` instance's `navigationItem`. {{site.data.alerts.end}}
+{% alert note %}
+To customize the navigation bar's title, set the title property of the `ABKContentCardsTableViewController` instance's `navigationItem`.
+{% endalert %}
 
 ### Modal Context
 
@@ -45,6 +49,8 @@ This modal is used to present the view controller in a modal view, with a naviga
 
 ```objc
 ABKContentCardsViewController *contentCards = [[ABKContentCardsViewController alloc] init];
+contentCards.contentCardsViewController.title = "Content Cards Title";
+contentCards.contentCardsViewController.disableUnreadIndicator = YES;
 [self.navigationController presentViewController:contentCards animated:YES completion:nil];
 ```
 
@@ -53,7 +59,7 @@ ABKContentCardsViewController *contentCards = [[ABKContentCardsViewController al
 
 ```swift
 let contentCards = ABKContentCardsViewController()
-contentCards.contentCardsViewController.title = "VC Title"
+contentCards.contentCardsViewController.title = "Content Cards Title"
 contentCards.contentCardsViewController.disableUnreadIndicator = true
 self.present(contentCards, animated: true, completion: nil)
 ```
@@ -63,7 +69,9 @@ self.present(contentCards, animated: true, completion: nil)
 
 For examples of these view controllers, check out our [Content Cards sample app](https://github.com/Appboy/appboy-ios-sdk/tree/master/Samples/ContentCards/BrazeContentCardsSampleApp).
 
-{{site.data.alerts.note}} To customize the header, set the title property of the `navigationItem` belonging to the `ABKContentCardsTableViewController` instance embedded in the parent `ABKContentCardsViewController` instance. {{site.data.alerts.end}}
+{% alert note %}
+To customize the header, set the title property of the `navigationItem` belonging to the `ABKContentCardsTableViewController` instance embedded in the parent `ABKContentCardsViewController` instance.
+{% endalert %}
 
 ## Customizing the Content Cards Feed
 

--- a/_docs/_developer_guide/platform_integration_guides/ios/content_cards/customization.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/content_cards/customization.md
@@ -25,14 +25,10 @@ ABKContentCardsTableViewController *contentCards = [ABKContentCardsTableViewCont
 {% tab swift %}
 
 ```swift
-// Initialize out-of-the-box content cards table view controller
-let contentCardsTVC = ABKContentCardsTableViewController()
-// Modify title of table view controller
-contentCardsTVC.title = "TVC Title"
-// Disable unread card indicator (the default value is false)
-contentCardsTVC.disableUnreadIndicator = true
-// Display content cards in navigation controller
-navigationController?.pushViewController(contentCardsTVC, animated: true)
+let contentCards = ABKContentCardsTableViewController()
+contentCards.title = "TVC Title"
+contentCards.disableUnreadIndicator = true
+navigationController?.pushViewController(contentCards, animated: true)
 ```
 
 {% endtab %}
@@ -56,14 +52,10 @@ ABKContentCardsViewController *contentCards = [[ABKContentCardsViewController al
 {% tab swift %}
 
 ```swift
-// Initialize out-of-the-box view controller
-let contentCardsVC = ABKContentCardsViewController()
-// Modify title view controller
-contentCardsVC.contentCardsViewController.title = "VC Title"
-// Disable unread card indicator (the default value is false)
-contentCardsVC.contentCardsViewController.disableUnreadIndicator = true
-// Display content cards in modal
-self.present(contentCardsVC, animated: true, completion: nil)
+let contentCards = ABKContentCardsViewController()
+contentCards.contentCardsViewController.title = "VC Title"
+contentCards.contentCardsViewController.disableUnreadIndicator = true
+self.present(contentCards, animated: true, completion: nil)
 ```
 
 {% endtab %}

--- a/_docs/_developer_guide/platform_integration_guides/ios/content_cards/customization.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/content_cards/customization.md
@@ -13,10 +13,30 @@ Content Cards can be integrated with two view controller contexts: Navigation or
 
 Example of pushing a `ABKContentCardsTableViewController` instance into a navigation controller:
 
+{% tabs %}
+{% tab OBJECTIVE-C %}
+
 ```objc
 ABKContentCardsTableViewController *contentCards = [ABKContentCardsTableViewController getNavigationFeedViewController];
 [self.navigationController pushViewController:contentCards animated:YES];
 ```
+
+{% endtab %}
+{% tab swift %}
+
+```swift
+// Initialize out-of-the-box content cards table view controller
+let contentCardsTVC = ABKContentCardsTableViewController()
+// Modify title of table view controller
+contentCardsTVC.title = "TVC Title"
+// Disable unread card indicator (the default value is false)
+contentCardsTVC.disableUnreadIndicator = true
+// Display content cards in navigation controller
+navigationController?.pushViewController(contentCardsTVC, animated: true)
+```
+
+{% endtab %}
+{% endtabs %}
 
 {{site.data.alerts.note}} To customize the navigation bar's title, set the title property of the `ABKContentCardsTableViewController` instance's `navigationItem`. {{site.data.alerts.end}}
 
@@ -24,10 +44,31 @@ ABKContentCardsTableViewController *contentCards = [ABKContentCardsTableViewCont
 
 This modal is used to present the view controller in a modal view, with a navigation bar on top and a Done button on the right side of the bar.
 
+{% tabs %}
+{% tab OBJECTIVE-C %}
+
 ```objc
 ABKContentCardsViewController *contentCards = [[ABKContentCardsViewController alloc] init];
 [self.navigationController presentViewController:contentCards animated:YES completion:nil];
 ```
+
+{% endtab %}
+{% tab swift %}
+
+```swift
+// Initialize out-of-the-box view controller
+let contentCardsVC = ABKContentCardsViewController()
+// Modify title view controller
+contentCardsVC.contentCardsViewController.title = "VC Title"
+// Disable unread card indicator (the default value is false)
+contentCardsVC.contentCardsViewController.disableUnreadIndicator = true
+// Display content cards in modal
+self.present(contentCardsVC, animated: true, completion: nil)
+```
+
+{% endtab %}
+{% endtabs %}
+
 For examples of these view controllers, check out our [Content Cards sample app](https://github.com/Appboy/appboy-ios-sdk/tree/master/Samples/ContentCards/BrazeContentCardsSampleApp).
 
 {{site.data.alerts.note}} To customize the header, set the title property of the `navigationItem` belonging to the `ABKContentCardsTableViewController` instance embedded in the parent `ABKContentCardsViewController` instance. {{site.data.alerts.end}}


### PR DESCRIPTION
# Pull Request/Issue Resolution

**Description of Change:**
Added swift code to display content cards through table view controller and view controller as modal and in navigation controller.

**Reason for Change:**
There was no Swift code on the Customization page of Content Cards, so I added some

Closes #**ISSUE_NUMBER_HERE**
iOS: swift examples for content cards documentation (PC-970)
More work still to be done. Planning on adding more swift snippets and open source example app in near future.

---
---

## PR Checklist
- [x] Ensure you have completed our CLA.
- [x] Tag @EmilyNecciai as a reviewer when the your work is done and ready to be reviewed for merge. 
- [x] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide) to be sure you're utilizing the proper markdown formatting.
- [x] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices) to be sure you're aligning with our voice and other style best practices.
- [x] [Preview your deployed changes](https://homeslice.braze.com/docs) to confirm that none of your changes break production. Pay close attention to links and images.
- [x] Tag others as Reviewers as necessary.
- [x] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
