### PR TITLE
Add variation ID to the Content Card Object for API campaigns

### DIFF
--- a/_docs/_api/endpoints/messaging.md
+++ b/_docs/_api/endpoints/messaging.md
@@ -823,6 +823,7 @@ You must include an Android Push Object in `messages` if you want users you have
   "type": (required, string) one of "CLASSIC", "CAPTIONED_IMAGE", or "BANNER",
   "title": (required, string) the card's title,
   "description": (required, string) the card's description,
+  "message_variation_id": (optional, string) used when providing a campaign_id to specify which message variation this message should be tracked under (must be a Content Card Message),
   "pinned": (optional, boolean) whether the card is pinned. Defaults to false,
   "image_url": (optional, string) the card's image URL. Required for "CAPTIONED_IMAGE" and "BANNER",
   "time_to_live": (optional, integer) the number of seconds before the card expires. You must include either "time_to_live" or "expire_at",


### PR DESCRIPTION
# Pull Request/Issue Resolution

**Description of Change:**
- Add `"message_variation_id"` to the Content Cad Object. Pattern matched the language to the other message objects (though I'm not sure if it's "must be a Content Card Message" or "must be a Content Card**s** Message".

**Reason for Change:**
- Should have been there from the start.

Closes #**ISSUE_NUMBER_HERE**


---
---

## PR Checklist
- [ ] Ensure you have completed our CLA.
- [x] Tag @EmilyNecciai as a reviewer when the your work is done and ready to be reviewed for merge. 
- [ ] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide) to be sure you're utilizing the proper markdown formatting.
- [ ] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices) to be sure you're aligning with our voice and other style best practices.
- [ ] [Preview your deployed changes](https://homeslice.braze.com/docs) to confirm that none of your changes break production. Pay close attention to links and images.
- [x] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
