### PR TITLE
Modernize ios custom endpoint docs

### DIFF
--- a/_docs/_developer_guide/eu01_us3_sdk_implementation_differences/for_ios.md
+++ b/_docs/_developer_guide/eu01_us3_sdk_implementation_differences/for_ios.md
@@ -8,38 +8,3 @@ page_order: 5
 To update the default endpoint in your integration of the Braze SDKs please add the following code:
 
 Starting with Braze iOS SDK v3.0.2, you can set a custom endpoint using the `Info.plist` file. Add the `Appboy` dictionary to your Info.plist file. Inside the `Appboy` dictionary, add the `Endpoint` string subentry and set the value to your custom endpoint url’s authority (for example, `sdk.iad-01.braze.com`, not `https://sdk.iad-01.braze.com`).
-
-In versions prior to 3.0.2, add the following class to your application, and then instantiate it and pass it in the `appboyOptions` dictionary you pass to `startWithApiKey:inApplication:withLaunchOptions:withAppboyOptions` with the key: `ABKAppboyEndpointDelegateKey`.
-
-```
-#import "Foundation/Foundation.h"
-#import "ABKAppboyEndpointDelegate.h"
-
-@interface AppboyEndpointDelegate : NSObject <ABKAppboyEndpointDelegate>
-@end
-
-@implementation AppboyEndpointDelegate
-- (NSString *) getApiEndpoint:(NSString *)appboyApiEndpoint {
-    return [appboyApiEndpoint stringByReplacingOccurrencesOfString:@"dev.appboy.com" withString:@"sdk.fra-01.braze.eu"];
-}
-
-@end
-```
-
-## For Xamarin iOS
-
-Pass into your StartWithApiKey call:
-
-```
-NSDictionary appboyOptions = new NSDictionary("ABKAppboyEndpointDelegate", new AppboyEndpointDelegate());
-
-Add the AppboyEndpointDelegate class:
-
-class AppboyEndpointDelegate : ABKAppboyEndpointDelegate
-{
-  public override String GetApiEndpoint(String appboyApiEndpoint)
-  {
-    return appboyApiEndpoint.Replace("dev.appboy.com", "sdk.fra-01.braze.eu");
-  }
-}
-```

--- a/_includes/archive/apple/initial_setup.md
+++ b/_includes/archive/apple/initial_setup.md
@@ -107,23 +107,6 @@ Your Braze representative should have already advised you of the [correct endpoi
 
 Starting with Braze iOS SDK v3.0.2, you can set a custom endpoint using the `Info.plist` file. Add the `Appboy` dictionary to your Info.plist file. Inside the `Appboy` dictionary, add the `Endpoint` string subentry and set the value to your custom endpoint url's authority (e.g. `sdk.iad-01.braze.com`, *not* `https://sdk.iad-01.braze.com`).
 
-In versions prior to 3.0.2, add the following class to your application, and then instantiate it and pass it in the `appboyOptions` dictionary you pass to `startWithApiKey:inApplication:withLaunchOptions:withAppboyOptions` with the key: `ABKAppboyEndpointDelegateKey`
-
-```
-#import "Foundation/Foundation.h"
-#import "ABKAppboyEndpointDelegate.h"
-
-@interface AppboyEndpointDelegate : NSObject <ABKAppboyEndpointDelegate>
-@end
-
-@implementation AppboyEndpointDelegate
-- (NSString *) getApiEndpoint:(NSString *)appboyApiEndpoint {
-    return [appboyApiEndpoint stringByReplacingOccurrencesOfString:@"dev.appboy.com" withString:@"YOUR_CUSTOM_ENDPOINT_OR_DATA_CLUSTER"];
-}
-
-@end
-```
-
 {% alert important %}
 To find out your specific cluster or custom endpoint, please ask your Customer Success Manager or reach out to our support team.
 {% endalert %}


### PR DESCRIPTION
1) The old integration examples are now broken due to us changing the default backend endpoint. 
2) We should not expose the backend endpoint as a public interface, which this old integration style does, so we should not present the old integration as an acceptable alternative.