### PR TITLE
Braze/Google Typo in Amp Docs

### DIFF
--- a/_docs/_hidden/private_betas/amphtml.md
+++ b/_docs/_hidden/private_betas/amphtml.md
@@ -9,7 +9,7 @@ With [AMP for Email](https://amp.dev/about/email), you can add interactive eleme
 
 ## Requirements
 
-Braze is not responsible for the customer registering with Braze or meeting the necessary security requirements.
+Braze is not responsible for the customer registering with Google or meeting the necessary security requirements.
 
 Requirement   | Description
 --------------| -----------


### PR DESCRIPTION
# Pull Request/Issue Resolution

**Description of Change:**
Typo: Braze is not responsible for the customer registering with Braze or meeting the necessary security requirements.
It should be "registering with Google..."

https://www.braze.com/docs/amphtml/#amp-for-email

