### PR TITLE
Updated Postman Collection docs to include quotes

### DIFF
--- a/_docs/_api/postman_collection.md
+++ b/_docs/_api/postman_collection.md
@@ -32,7 +32,7 @@ The Braze Postman Collection uses a templating variable, `{{instanceURL}}`, to s
 1. Click on the gear icon in the top right corner of the Postman app. ![Managing Environments][2]{: height="40%" width="40%"}
 2. Select "Manage Environments" to open a modal window which displays your active environments.
 3. In the bottom right corner of the modal window, click "Add" to create a new environment.
-4. Give this environment a name (e.g. "Braze API Requests") and add keys for `instance_url` and `api_key` with values corresponding to your Braze REST API URL and Braze REST API Key as pictured below. The `api_key` should __not__ be encapsulated in quotes.
+4. Give this environment a name (e.g. "Braze API Requests") and add keys for `instance_url` and `api_key` with values corresponding to your Braze REST API URL and Braze REST API Key as pictured below. The `api_key` should be encapsulated in quotes.
   - The value that you need to add for `instance_url` is dependent on your Braze instance. For more information, please see our [Rest API "Endpoint" documentation.][7]
   - For more information on your `api_key` please see our ["App Group REST API Key" documentation.][8]
 


### PR DESCRIPTION
api_key variable in JSON does require " " either side of the value. have removed the *not* from this paragraph.

# Pull Request/Issue Resolution

**Description of Change:**
The previous paragraph suggested that the variable of api_key did not require quotes, however, in Postman this value does require quotes.
**Reason for Change:**
Makes the setting up of the Postman environment more clear to the customer.
Closes #**ISSUE_NUMBER_HERE**


---
---

## PR Checklist
- [ ] Ensure you have completed our CLA.
- [ ] Tag @EmilyNecciai as a reviewer when the your work is done and ready to be reviewed for merge. 
- [ ] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide) to be sure you're utilizing the proper markdown formatting.
- [ ] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices) to be sure you're aligning with our voice and other style best practices.
- [ ] [Preview your deployed changes](https://homeslice.braze.com/docs) to confirm that none of your changes break production. Pay close attention to links and images.
- [ ] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
