### PR TITLE
Updated links to example `appboy.xml` and `AndroidManifest.xml`

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/android/initial_sdk_setup/android_sdk_integration.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/initial_sdk_setup/android_sdk_integration.md
@@ -70,6 +70,10 @@ Now that the libraries have been integrated, you have to create an `appboy.xml` 
 </resources>
 ```
 
+**Implementation Example**
+
+See the [`appboy.xml`][6] in the Droidboy sample app for an implementation example.
+
 ### Step 3: Add Required Permissions to Android Manifest
 Now that you've added your API key, you need to add the following permissions to your `AndroidManifest.xml`:
 
@@ -82,7 +86,7 @@ Now that you've added your API key, you need to add the following permissions to
 
 **Implementation Example**
 
-See the [`appboy.xml`][6] in the Droidboy sample app for an implementation example.
+See the [`AndroidManifest.xml`][69] in the Droidboy sample app for an implementation example.
 
 ### Step 4: Tracking User Sessions in Android
 
@@ -184,3 +188,4 @@ Please see the following sections in order to enable [custom event tracking]({{ 
 [66]: {{ site.baseurl }}/developer_guide/eu01_us3_sdk_implementation_differences/overview/
 [67]: {{ site.baseurl }}/developer_guide/eu01_us3_sdk_implementation_differences/overview/#sdk-implementation
 [68]: {{ site.baseurl }}/support_contact/
+[69]: https://github.com/Appboy/appboy-android-sdk/blob/master/droidboy/src/main/AndroidManifest.xml


### PR DESCRIPTION
**Description of Change:**
This updates links in the [Android SDK Initial SDK Setup guide](https://www.braze.com/docs/developer_guide/platform_integration_guides/android/initial_sdk_setup/android_sdk_integration/#step-3-add-required-permissions-to-android-manifest).

* Step 3 should include an example link to `AndroidManifest.xml` (not `appboy.xml`)
* Step 2 should include a link to `appboy.xml` 


---
---

## PR Checklist
- [ ] Ensure you have completed our CLA.
- [ ] Tag @EmilyNecciai as a reviewer when the your work is done and ready to be reviewed for merge. 
- [ ] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide) to be sure you're utilizing the proper markdown formatting.
- [ ] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices) to be sure you're aligning with our voice and other style best practices.
- [ ] [Preview your deployed changes](https://homeslice.braze.com/docs) to confirm that none of your changes break production. Pay close attention to links and images.
- [ ] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
