### PR TITLE
Updating Labels link to point to label configuration page

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -14,7 +14,7 @@
 ## Before You Submit
 
 - [ ] Fill out the relevant items under __Submit an Issue__ above.
-- [ ] [Label](https://github.com/Appboy/braze-docs/wiki/Labels) this issue.
+- [ ] [Label](https://github.com/Appboy/braze-docs/issues/labels) this issue.
 - [ ] Assign this issue to either yourself, the Technical Writer (@EmilyNecciai), or to another appropriate person. _If you do not assign anyone to an issue, your issue may be closed._
 
 ---


### PR DESCRIPTION
# Pull Request/Issue Resolution

**Description of Change:**
Issue template had a link for Labels which pointed to a new wiki page creation, instead of the labels page.


---
---

## PR Checklist
- [x] Ensure you have completed our CLA.
- [x] Tag @EmilyNecciai as a reviewer when the your work is done and ready to be reviewed for merge. 
- [x] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide) to be sure you're utilizing the proper markdown formatting.
- [x] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices) to be sure you're aligning with our voice and other style best practices.
- [x] [Preview your deployed changes](https://homeslice.braze.com/docs) to confirm that none of your changes break production. Pay close attention to links and images.
- [x] Tag others as Reviewers as necessary.
- [x] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
