### PR TITLE
Add dispatch_id to list of available campaign attributes, with note a…

### DIFF
--- a/_docs/_user_guide/personalization_and_dynamic_content/liquid/supported_personalization_tags.md
+++ b/_docs/_user_guide/personalization_and_dynamic_content/liquid/supported_personalization_tags.md
@@ -14,7 +14,7 @@ As a convenience, a summary of supported personalization tags are listed below. 
 | Default Attributes | `{{${city}}}` <br> `{{${country}}}` <br> `{{${date_of_birth}}}` <br> `{{${email_address}}}` <br> `{{${first_name}}}` <br> `{{${gender}}}` <br> `{{${language}}}` <br> `{{${last_name}}}` <br> `{{${last_used_app_date}}}` <br> `{{${most_recent_app_version}}}` <br> `{{${most_recent_locale}}}` <br> `{{${most_recent_location}}}` <br> `{{${phone_number}}}` <br> `{{${time_zone}}}` <br> `{{${twitter_handle}}}` <br> `{{${user_id}}}` <br> `{{${braze_id}}}` |
 | Device Attributes | `{{most_recently_used_device.${carrier}}}` <br> `{{most_recently_used_device.${id}}}` <br> `{{most_recently_used_device.${idfa}}}` <br> `{{most_recently_used_device.${model}}}` <br> `{{most_recently_used_device.${os}}}` <br> `{{most_recently_used_device.${platform}}}` |
 | Email List Attributes <br> (Learn more [here][43]). | `{{${set_user_to_unsubscribed_url}}}` <br> `{{${set_user_to_subscribed_url}}}` <br> `{{${set_user_to_opted_in_url}}}` |
-| Campaign Attributes | `{{campaign.${api_id}}}` <br> `{{campaign.${name}}}` |
+| Campaign Attributes | `{{campaign.${api_id}}}` <br> `{{campaign.${dispatch_id}}}` <br> `{{campaign.${name}}}` |
 | Canvas Attributes | `{{canvas.${name}}}` <br> `{{canvas.${api_id}}}` <br> `{{canvas.${variant_name}}}` <br> `{{canvas.${variant_api_id}}}` |
 | Card Attributes | `{{card.${api_id}}}` <br> `{{card.${name}}}` |
 | Event Properties <br> (These are custom to your app group.)| `{{event_properties.${your_custom_event_property}}}` |
@@ -23,7 +23,7 @@ As a convenience, a summary of supported personalization tags are listed below. 
 {% endraw %}
 
 {% alert important %}
-Campaign, Card, and Canvas attributes are only supported in their corresponding messaging templates.
+Campaign, Card, and Canvas attributes are only supported in their corresponding messaging templates. (i.e. - `dispatch_id` is not available in In-App Message campaigns)
 {% endalert %}
 
 

--- a/_docs/_user_guide/personalization_and_dynamic_content/liquid/supported_personalization_tags.md
+++ b/_docs/_user_guide/personalization_and_dynamic_content/liquid/supported_personalization_tags.md
@@ -23,7 +23,7 @@ As a convenience, a summary of supported personalization tags are listed below. 
 {% endraw %}
 
 {% alert important %}
-Campaign, Card, and Canvas attributes are only supported in their corresponding messaging templates. (i.e. - `dispatch_id` is not available in In-App Message campaigns)
+Campaign, Card, and Canvas attributes are only supported in their corresponding messaging templates (for example, `dispatch_id` is not available in in-app message campaigns).
 {% endalert %}
 
 


### PR DESCRIPTION
…bout IAMs

Quick PR to add `dispatch_id` to the list of campaign attributes available in liquid personalization, along with a note about that field not being available in IAMs

This should be merged for the July 9th docs release as this feature is being released then.


---
---

## PR Checklist
- [ ] Ensure you have completed our CLA.
- [ ] Tag @EmilyNecciai as a reviewer when the your work is done and ready to be reviewed for merge. 
- [ ] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide) to be sure you're utilizing the proper markdown formatting.
- [ ] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices) to be sure you're aligning with our voice and other style best practices.
- [ ] [Preview your deployed changes](https://homeslice.braze.com/docs) to confirm that none of your changes break production. Pay close attention to links and images.
- [ ] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
