### PR TITLE
Remove limited access banner from campaign comparisons docs

### DIFF
--- a/_docs/_user_guide/engagement_tools/campaigns/testing_and_more/comparing_campaigns.md
+++ b/_docs/_user_guide/engagement_tools/campaigns/testing_and_more/comparing_campaigns.md
@@ -7,10 +7,6 @@ page_order: 7
 
 # Comparing Campaigns
 
-{% alert important %}
-The Campaign Comparison feature is currently in limited release. Please contact your Account Manager or Customer Success Manager if you are interested in using this feature.
-{% endalert %}
-
 Braze allows you to view high-level details from multiple campaigns in a single view, allowing you to compare overall performance for up to 10 campaigns.
 
 Get started by visiting the Campaigns page in the Dashboard. From there, click the "Compare" button in the top right of the campaign grid.


### PR DESCRIPTION
Quick PR to remove the limited access banner note from Campaign Comparisons, since this feature is going GA on July 9th.

This PR should be merged in with the July 9th docs release.


---
---

## PR Checklist
- [ ] Ensure you have completed our CLA.
- [ ] Tag @EmilyNecciai as a reviewer when the your work is done and ready to be reviewed for merge. 
- [ ] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide) to be sure you're utilizing the proper markdown formatting.
- [ ] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices) to be sure you're aligning with our voice and other style best practices.
- [ ] [Preview your deployed changes](https://homeslice.braze.com/docs) to confirm that none of your changes break production. Pay close attention to links and images.
- [ ] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
