### PR TITLE
add image to glossary

### DIFF
--- a/_layouts/glossary_page.html
+++ b/_layouts/glossary_page.html
@@ -279,6 +279,9 @@ $(document).ready(function() {
         <span id="filter_{{ glossary_id }}" class="term">
           <h2 id="{{ glossary_id }}"></h2>
           <div class="content"><p class="title">{{ glossary['name'] }}</p>
+            {%- if glossary['image'] -%}
+            <img src="{{ glossary['image'] }}" />
+            {%- endif -%}
             <p class="desc">{{ glossary['description'] }}</p>
             {%- if glossary['metric'] -%}
             <div class="metric">Metric: {{ glossary['metric'] }}</div>


### PR DESCRIPTION
# Pull Request/Issue Resolution
Add image tag to glossary_page layout. use the addtional `image` parameter. Example:

```
 image: /docs/assets/img_archive/rest-api-key.png?23c30d863f24a741e6837264a3491564```

