### PR TITLE
Fix some en spaces -> spaces in JSON examples

### DIFF
--- a/_docs/_api/endpoints/user_data.md
+++ b/_docs/_api/endpoints/user_data.md
@@ -138,7 +138,7 @@ POST https://YOUR_REST_API_URL/users/track
 Content-Type: application/json
 {
   "api_key" : "your App Group REST API Key",
-  "attributes" : [
+  "attributes" : [
     {
       "external_id" : "user1",
       "first_name" : "Jon",
@@ -146,7 +146,7 @@ Content-Type: application/json
       "dob": "1988-02-14",
       "music_videos_favorited" : { "add" : [ "calvinharris-summer" ], "remove" : ["nickiminaj-anaconda"] }
     },
-    {
+    {
       "external_id" : "user2",
       "first_name" : "Jill",
       "has_profile_picture" : false,
@@ -194,7 +194,7 @@ POST https://YOUR_REST_API_URL/users/track
 Content-Type: application/json
 {
   "api_key" : "your App Group REST API Key",
-  "events" : [
+  "events" : [
     {
       "external_id" : "user1",
       "app_id" : "your-app-id",
@@ -250,7 +250,7 @@ POST https://YOUR_REST_API_URL/users/track
 Content-Type: application/json
 {
   "api_key" : "your App Group REST API Key",
-  "purchases" : [
+  "purchases" : [
     {
       "external_id" : "user1",
       "app_id" : "11ae5b4b-2445-4440-a04f-bf537764c9ad",


### PR DESCRIPTION
# Pull Request/Issue Resolution

**Description of Change:**
Replaces some en-spaces with normal spaces

**Reason for Change:**
I was using the docs, copy pasted a JSON post body example and had a bad time. It was invalid JSON because some of the whitespace was en-spaces instead of regular.



---
---

## PR Checklist
- [ ] Ensure you have completed our CLA.
- [ ] Tag @EmilyNecciai as a reviewer when the your work is done and ready to be reviewed for merge. 
- [ ] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide) to be sure you're utilizing the proper markdown formatting.
- [ ] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices) to be sure you're aligning with our voice and other style best practices.
- [ ] [Preview your deployed changes](https://homeslice.braze.com/docs) to confirm that none of your changes break production. Pay close attention to links and images.
- [ ] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
