### PR TITLE
Manual integration fix Docs update

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/manual_integration_options.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/manual_integration_options.md
@@ -54,7 +54,8 @@ If you try to use the core version of the SDK without Braze's UI features, in-ap
 	- `Accounts.framework`
 	- `AdSupport.framework`
 	- `StoreKit.framework`
-7. The SDWebImage framework is required for the Braze News Feed, Content Cards and In-App Messaging to function properly. SDWebImage is used for image downloading and displaying, including GIFs. If you intend to use the News Feed, Content Cards or In-App Messages, please follow the steps below.
+7. While still under the target for your project, select the "Build Settings" tab. In the "Linking" section, locate the "Other Linker Flags" setting and add the `-ObjC` flag.
+8. The SDWebImage framework is required for the Braze News Feed, Content Cards and In-App Messaging to function properly. SDWebImage is used for image downloading and displaying, including GIFs. If you intend to use the News Feed, Content Cards or In-App Messages, please follow the steps below.
 
 {% alert warning %}  
 From version 2.26.0, Braze iOS SDK only supports 4.x version of SDWebImage. If you have to use SDWebImage version 3.x, please use Braze SDK version 2.25.0 or below.
@@ -69,8 +70,8 @@ git clone --recursive https://github.com/rs/SDWebImage.git
 2. Drag-n-drop `SDWebImage/SDWebImage.xcodeproj` into your application Xcode project.
 3. In your project application’s target settings, open the "General" tab, click the "+" button under the "Link Frameworks and Libraries" block and add `ImageIO.framework`.
 4. In your project application’s target settings, open the "General" tab, click the "+" button under the "Embedded Binaries" block and add `SDWebImage.framework`.
-5. In the `SDWebImage` project settings, open the "Build Settings" tab, in the "Linking" section, locate the "Other Linker Flags" setting and add the `-ObjC` flag.
-6. In your project application's target settings, open the "Build Settings", in the "Search Paths" section, locate "Header Search Paths" and add `$(SRCROOT)/SDWebImage` with "recursive" turned on.
+5. In the `SDWebImage` project settings, open the "Build Settings" tab. In the "Linking" section, locate the "Other Linker Flags" setting and add the `-ObjC` flag if it isn't already present.
+6. In your project application's target settings, open the "Build Settings" tab. In the "Search Paths" section, locate "Header Search Paths" and add `$(SRCROOT)/SDWebImage` with "recursive" turned on.
 
 #### Optional Location Tracking
 


### PR DESCRIPTION
# Pull Request/Issue Resolution
https://jira.braze.com/browse/PC-1124

**Description of Change:**
When creating a static library, by default the linker is unaware of the methods defined in Category classes. In order to link them together, we need to add a new flag to the target of the project to look for these methods in category files when constructing the executable.
More info on this topic here:
https://stackoverflow.com/questions/6820778/linking-objective-c-categories-in-a-static-library

We just need a docs update with this step rather than needing to re-release our SDK 👍

**Reason for Change:**

Closes https://jira.braze.com/browse/PC-1124

---
---

## PR Checklist
- [ ] Ensure you have completed our CLA.
- [ ] Tag @EmilyNecciai as a reviewer when the your work is done and ready to be reviewed for merge. 
- [ ] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide) to be sure you're utilizing the proper markdown formatting.
- [ ] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices) to be sure you're aligning with our voice and other style best practices.
- [ ] [Preview your deployed changes](https://homeslice.braze.com/docs) to confirm that none of your changes break production. Pay close attention to links and images.
- [ ] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
