### PR TITLE
Add documentation for custom handling of HTML IAMs actions in Android.

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/android/in-app_messaging/customization.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/in-app_messaging/customization.md
@@ -207,9 +207,9 @@ See [`InAppMessageTesterFragment.java`][2] in the DroidBoy sample app for an exa
 
 ## Setting a Custom HTML In-App Message Action Listener
 
-The Braze SDK has a default `AppboyDefaultHtmlInAppMessageActionListener` class which is used if no custom listener is defined and logs the events. If you require more control over how user interacts with different buttons inside a HTML in-app message, implement a custom `IHtmlInAppMessageActionListener` class.
+The Braze SDK has a default `AppboyDefaultHtmlInAppMessageActionListener` class that is used if no custom listener is defined and takes appropriate action automatically. If you require more control over how a user interacts with different buttons inside a custom HTML in-app message, implement a custom `IHtmlInAppMessageActionListener` class.
 
-### Step 1: Implement a HTML In-App Message Action Listener
+### Step 1: Implement a Custom HTML In-App Message Action Listener
 
 Create a class that implements [`IHtmlInAppMessageActionListener`][86].
 

--- a/_docs/_developer_guide/platform_integration_guides/android/in-app_messaging/customization.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/in-app_messaging/customization.md
@@ -207,11 +207,11 @@ See [`InAppMessageTesterFragment.java`][2] in the DroidBoy sample app for an exa
 
 ## Setting a Custom HTML In-App Message Action Listener
 
-Braze's SDK have a default `AppboyDefaultHtmlInAppMessageActionListener` class which is used if no custom listener is defined and logs the events. If you require more control over how user interacts with different buttons inside a HTML in-app message, implement a custom `IHtmlInAppMessageActionListener` class.
+The Braze SDK has a default `AppboyDefaultHtmlInAppMessageActionListener` class which is used if no custom listener is defined and logs the events. If you require more control over how user interacts with different buttons inside a HTML in-app message, implement a custom `IHtmlInAppMessageActionListener` class.
 
 ### Step 1: Implement a HTML In-App Message Action Listener
 
-Create a class that implements [`IHtmlInAppMessageActionListener`][86]
+Create a class that implements [`IHtmlInAppMessageActionListener`][86].
 
 The callbacks in your `IHtmlInAppMessageActionListener` will be called whenever user initiates any of the following actions inside HTML in-app message:
 - Clicks on close button.
@@ -219,7 +219,78 @@ The callbacks in your `IHtmlInAppMessageActionListener` will be called whenever 
 - Fires a custom event.
 - Clicks on a URL inside HTML in-app message.
 
-See [`CustomHtmlInAppMessageActionListener.java`][87] in our Droidboy sample app for an implementation example.
+{% tabs %}
+{% tab JAVA %}
+
+
+```java
+public class CustomHtmlInAppMessageActionListener implements IHtmlInAppMessageActionListener {
+  private final Context mContext;
+
+  public CustomHtmlInAppMessageActionListener(Context context) {
+    mContext = context;
+  }
+
+  @Override
+  public void onCloseClicked(IInAppMessage inAppMessage, String url, Bundle queryBundle) {
+    Toast.makeText(mContext, "HTML In App Message closed", Toast.LENGTH_LONG).show();
+    AppboyInAppMessageManager.getInstance().hideCurrentlyDisplayingInAppMessage(false);
+  }
+
+  @Override
+  public boolean onCustomEventFired(IInAppMessage inAppMessage, String url, Bundle queryBundle) {
+    Toast.makeText(mContext, "Custom event fired. Ignoring.", Toast.LENGTH_LONG).show();
+    return true;
+  }
+
+  @Override
+  public boolean onNewsfeedClicked(IInAppMessage inAppMessage, String url, Bundle queryBundle) {
+    Toast.makeText(mContext, "Newsfeed button pressed. Ignoring.", Toast.LENGTH_LONG).show();
+    AppboyInAppMessageManager.getInstance().hideCurrentlyDisplayingInAppMessage(false);
+    return true;
+  }
+
+  @Override
+  public boolean onOtherUrlAction(IInAppMessage inAppMessage, String url, Bundle queryBundle) {
+    Toast.makeText(mContext, "Custom url pressed: " + url + " . Ignoring", Toast.LENGTH_LONG).show();
+    AppboyInAppMessageManager.getInstance().hideCurrentlyDisplayingInAppMessage(false);
+    return true;
+  }
+}
+```
+
+{% endtab %}
+{% tab KOTLIN %}
+
+```kotlin
+class CustomHtmlInAppMessageActionListener(private val mContext: Context) : IHtmlInAppMessageActionListener {
+
+    override fun onCloseClicked(inAppMessage: IInAppMessage, url: String, queryBundle: Bundle) {
+        Toast.makeText(mContext, "HTML In App Message closed", Toast.LENGTH_LONG).show()
+        AppboyInAppMessageManager.getInstance().hideCurrentlyDisplayingInAppMessage(false)
+    }
+
+    override fun onCustomEventFired(inAppMessage: IInAppMessage, url: String, queryBundle: Bundle): Boolean {
+        Toast.makeText(mContext, "Custom event fired. Ignoring.", Toast.LENGTH_LONG).show()
+        return true
+    }
+
+    override fun onNewsfeedClicked(inAppMessage: IInAppMessage, url: String, queryBundle: Bundle): Boolean {
+        Toast.makeText(mContext, "Newsfeed button pressed. Ignoring.", Toast.LENGTH_LONG).show()
+        AppboyInAppMessageManager.getInstance().hideCurrentlyDisplayingInAppMessage(false)
+        return true
+    }
+
+    override fun onOtherUrlAction(inAppMessage: IInAppMessage, url: String, queryBundle: Bundle): Boolean {
+        Toast.makeText(mContext, "Custom url pressed: $url . Ignoring", Toast.LENGTH_LONG).show()
+        AppboyInAppMessageManager.getInstance().hideCurrentlyDisplayingInAppMessage(false)
+        return true
+    }
+}
+```
+
+{% endtab %}
+{% endtabs %}
 
 ### Step 2: Instruct Braze to use your HTML In-App Message Action Listener
 
@@ -227,7 +298,23 @@ Once your `IHtmlInAppMessageActionListener` is created, call `AppboyInAppMessage
 
 We recommend setting your `IHtmlInAppMessageActionListener` in your [`Application.onCreate()`][82] before any other calls to Braze. This will ensure that the custom action listener is set before any in-app message is displayed.
 
-See [`InAppMessageTesterFragment.java`][2] in the DroidBoy sample app for an example implementation.
+{% tabs %}
+{% tab JAVA %}
+
+
+```java
+AppboyInAppMessageManager.getInstance().setCustomHtmlInAppMessageActionListener(new CustomHtmlInAppMessageActionListener(context));
+```
+
+{% endtab %}
+{% tab KOTLIN %}
+
+```kotlin
+AppboyInAppMessageManager.getInstance().setCustomHtmlInAppMessageActionListener(new CustomHtmlInAppMessageActionListener(context))
+```
+
+{% endtab %}
+{% endtabs %}
 
 ## Setting Fixed Orientation
 
@@ -337,4 +424,3 @@ Starting in Braze Android SDK version 2.0.1, Youtube and other HTML5 content can
 [84]: https://developer.android.com/guide/topics/graphics/hardware-accel.html#controlling
 [85]: https://developer.android.com/guide/topics/ui/dialogs.html
 [86]: https://github.com/Appboy/appboy-android-sdk/blob/master/android-sdk-ui/src/main/java/com/appboy/ui/inappmessage/listeners/IHtmlInAppMessageActionListener.java
-[87]: https://github.com/Appboy/appboy-android-sdk/blob/master/droidboy/src/main/java/com/appboy/sample/CustomHtmlInAppMessageActionListener.java

--- a/_docs/_developer_guide/platform_integration_guides/android/in-app_messaging/customization.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/in-app_messaging/customization.md
@@ -80,6 +80,7 @@ Before customizing in-app messages with custom listeners, it's important to unde
 - [`IInAppMessageManagerListener`][21] - Implement to [custom manage in-app message display and behavior](#setting-a-custom-manager-listener).
 - [`IInAppMessageViewFactory`][42] - Implement to [build custom in-app message views](#setting-a-custom-view-factory).
 - [`IInAppMessageAnimationFactory`][20] - Implement to [define custom in-app message animations](#setting-a-custom-animation-factory).
+- [`IHtmlInAppMessageActionListener`][86] - Implement to [custom manage HTML in-app message display and behavior](#setting-a-custom-html-in-app-message-action-listener).
 
 ### Setting a Custom Manager Listener
 
@@ -204,6 +205,30 @@ We recommend setting your `IInAppMessageAnimationFactory` in your [`Application.
 
 See [`InAppMessageTesterFragment.java`][2] in the DroidBoy sample app for an example implementation.
 
+## Setting a Custom HTML In-App Message Action Listener
+
+Braze's SDK have a default `AppboyDefaultHtmlInAppMessageActionListener` class which is used if no custom listener is defined and logs the events. If you require more control over how user interacts with different buttons inside a HTML in-app message, implement a custom `IHtmlInAppMessageActionListener` class.
+
+### Step 1: Implement a HTML In-App Message Action Listener
+
+Create a class that implements [`IHtmlInAppMessageActionListener`][86]
+
+The callbacks in your `IHtmlInAppMessageActionListener` will be called whenever user initiates any of the following actions inside HTML in-app message:
+- Clicks on close button.
+- Clicks on news feed button.
+- Fires a custom event.
+- Clicks on a URL inside HTML in-app message.
+
+See [`CustomHtmlInAppMessageActionListener.java`][87] in our Droidboy sample app for an implementation example.
+
+### Step 2: Instruct Braze to use your HTML In-App Message Action Listener
+
+Once your `IHtmlInAppMessageActionListener` is created, call `AppboyInAppMessageManager.getInstance().setCustomHtmlInAppMessageActionListener()` to instruct `AppboyInAppMessageManager` to use your custom `IHtmlInAppMessageActionListener` instead of the default action listener.
+
+We recommend setting your `IHtmlInAppMessageActionListener` in your [`Application.onCreate()`][82] before any other calls to Braze. This will ensure that the custom action listener is set before any in-app message is displayed.
+
+See [`InAppMessageTesterFragment.java`][2] in the DroidBoy sample app for an example implementation.
+
 ## Setting Fixed Orientation
 
 To set a fixed orientation for an in-app message, first [set a custom in-app message manager listener][19]. Then, call `setOrientation()` on the `IInAppMessage` object in the `beforeInAppMessageDisplayed()` delegate method.
@@ -311,3 +336,5 @@ Starting in Braze Android SDK version 2.0.1, Youtube and other HTML5 content can
 [83]: https://github.com/Appboy/appboy-android-sdk/blob/master/android-sdk-ui/src/main/java/com/appboy/ui/inappmessage/InAppMessageOperation.java
 [84]: https://developer.android.com/guide/topics/graphics/hardware-accel.html#controlling
 [85]: https://developer.android.com/guide/topics/ui/dialogs.html
+[86]: https://github.com/Appboy/appboy-android-sdk/blob/master/android-sdk-ui/src/main/java/com/appboy/ui/inappmessage/listeners/IHtmlInAppMessageActionListener.java
+[87]: https://github.com/Appboy/appboy-android-sdk/blob/master/droidboy/src/main/java/com/appboy/sample/CustomHtmlInAppMessageActionListener.java

--- a/_docs/_developer_guide/platform_integration_guides/android/in-app_messaging/customization.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/in-app_messaging/customization.md
@@ -222,7 +222,6 @@ The callbacks in your `IHtmlInAppMessageActionListener` will be called whenever 
 {% tabs %}
 {% tab JAVA %}
 
-
 ```java
 public class CustomHtmlInAppMessageActionListener implements IHtmlInAppMessageActionListener {
   private final Context mContext;
@@ -300,7 +299,6 @@ We recommend setting your `IHtmlInAppMessageActionListener` in your [`Applicatio
 
 {% tabs %}
 {% tab JAVA %}
-
 
 ```java
 AppboyInAppMessageManager.getInstance().setCustomHtmlInAppMessageActionListener(new CustomHtmlInAppMessageActionListener(context));


### PR DESCRIPTION
# Pull Request/Issue Resolution
https://jira.braze.com/browse/PC-1004

**Description of Change:**
When showing an HTML in-app message in Android, users can override default action listener for their custom handling of certain events. 

**Reason for Change:**
The HTML in-app message custom action listener was not documented previously and a customer requested for information on how to implement it.

Closes https://jira.braze.com/browse/PC-1004


---
---

## PR Checklist
- [x] Ensure you have completed our CLA.
- [x] Tag @EmilyNecciai as a reviewer when the your work is done and ready to be reviewed for merge. 
- [x] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide) to be sure you're utilizing the proper markdown formatting.
- [x] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices) to be sure you're aligning with our voice and other style best practices.
- [x] [Preview your deployed changes](https://homeslice.braze.com/docs) to confirm that none of your changes break production. Pay close attention to links and images.
- [x] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
