### PR TITLE
Android - Update docs for disable location collection by default.

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/android/advanced_use_cases/locations_and_geofences.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/advanced_use_cases/locations_and_geofences.md
@@ -15,10 +15,6 @@ To support geofences for Android:
 
 2. Braze location collection must not be disabled.
 
-{% alert important %}
-Braze location collection is enabled by default. To verify your location collection status on Android, ensure that `com_appboy_disable_location_collection` is not set to `true` in your `appboy.xml`.
-{% endalert %}
-
 ### Step 1: Update build.gradle
 
 Add the [Google Play Services Location package][3] to your app level `build.gradle` using the [Google Play Services setup guide][10]:
@@ -63,7 +59,18 @@ If you are using a version of the Android SDK less than `2.3.0`, the following m
 ```
 {% endalert %}
 
-### Step 3: Obtain Location Permissions from the End User
+### Step 3: Update the appboy.xml
+To enable Braze location collection, update your `appboy.xml` file to include `com_appboy_enable_location_collection` and ensure it's value is set to true.
+
+```xml
+<bool name="com_appboy_enable_location_collection">true</bool>
+```
+
+{% alert important %}
+Braze location collection is disabled by default.
+{% endalert %}
+
+### Step 4: Obtain Location Permissions from the End User
 
 For Android M and higher versions, you must request location permissions from the end user before gathering location information or registering geofences.
 
@@ -90,7 +97,7 @@ This will cause the SDK to request geofences from Braze's servers and initialize
 
 See [`RuntimePermissionUtils.java`][4] in our sample application for an example implementation.
 
-### Step 4: Enable Geofences on the Dashboard
+### Step 5: Enable Geofences on the Dashboard
 
 Android only allows up to 100 geofences to be stored for a given app. Braze's Locations product will use up to 20 of these geofence slots if available. To prevent accidental or unwanted disruption to other geofence-related functionality in your app, location geofences must be enabled for individual Apps on the Dashboard.
 

--- a/_docs/_developer_guide/platform_integration_guides/android/advanced_use_cases/locations_and_geofences.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/advanced_use_cases/locations_and_geofences.md
@@ -67,7 +67,7 @@ To enable Braze location collection, update your `appboy.xml` file to include `c
 ```
 
 {% alert important %}
-Braze location collection is disabled by default.
+Starting with Braze Android SDK version 3.6.0 Braze location collection is disabled by default.
 {% endalert %}
 
 ### Step 4: Obtain Location Permissions from the End User

--- a/_docs/_developer_guide/platform_integration_guides/android/advanced_use_cases/locations_and_geofences.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/advanced_use_cases/locations_and_geofences.md
@@ -59,8 +59,8 @@ If you are using a version of the Android SDK less than `2.3.0`, the following m
 ```
 {% endalert %}
 
-### Step 3: Update the appboy.xml
-To enable Braze location collection, update your `appboy.xml` file to include `com_appboy_enable_location_collection` and ensure it's value is set to true.
+### Step 3: Enable Braze Location Collection
+To enable Braze location collection, update your `appboy.xml` file to include `com_appboy_enable_location_collection` and ensure its value is set to true.
 
 ```xml
 <bool name="com_appboy_enable_location_collection">true</bool>

--- a/_docs/_developer_guide/platform_integration_guides/android/analytics/location_tracking.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/analytics/location_tracking.md
@@ -18,17 +18,17 @@ Or:
 ```
 
 {% alert important %}
-  With the release of Android M, Android switched from an install-time to a runtime permissions model. To enable location tracking on devices running M and above, the app must explicitly receive permission to use location from the user (Braze will not do this). Once location permissions are obtained, Braze will automatically begin tracking location on the next session start. Devices running earlier versions of Android only require location permissions to be declared in the `AndroidManifest.xml`. For more information, visit Android's [permission documentation](https://developer.android.com/training/permissions/index.html).
+  With the release of Android M, Android switched from an install-time to a runtime permissions model. To enable location tracking on devices running M and above, the app must explicitly receive permission to use location from the user (Braze will not do this). Once location permissions are obtained, Braze will automatically begin tracking location on the next session start, if location collection is enabled in `appboy.xml`. Devices running earlier versions of Android only require location permissions to be declared in the `AndroidManifest.xml`. For more information, visit Android's [permission documentation](https://developer.android.com/training/permissions/index.html).
 {% endalert %}
 
 `ACCESS_FINE_LOCATION` includes GPS data in reporting user location while `ACCESS_COARSE_LOCATION` includes data from the most battery-efficient non-GPS provider available (e.g. the network). Coarse location location will likely be sufficient for the majority of location data use-cases; however, under the runtime permissions model, receiving location permission from the user implicitly authorizes the collection of fine location data. You can read more about the differences between these location permissions and how you ought to utilize them [here][1].
 
 ### Disabling Automatic Location Tracking
 
-To disable automatic location tracking, set `com_appboy_disable_location_collection` to true in `appboy.xml`:
+To disable automatic location tracking, set `com_appboy_enable_location_collection` to false in `appboy.xml`:
 
 ```xml
-<bool name="com_appboy_disable_location_collection">true</bool>
+<bool name="com_appboy_enable_location_collection">false</bool>
 ```
 
 Then you can manually log single location data points via the setLastKnownLocation() method on `AppboyUser` like this:


### PR DESCRIPTION
# Pull Request/Issue Resolution

**Description of Change:**
By default, Braze Android SDK will not collect location information automatically. Developers will have to explicitly enable location collection by setting the com_appboy_enable_location_collection flag in appboy.xml

**Reason for Change:**
Android SDK is being updated to disable location collection by default. Updating Braze documentation to call out this change specifically for informing developers.

Closes #**ISSUE_NUMBER_HERE**
https://jira.braze.com/browse/PC-1105

---
---

## PR Checklist
- [x] Ensure you have completed our CLA.
- [x] Tag @EmilyNecciai as a reviewer when the your work is done and ready to be reviewed for merge. 
- [x] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide) to be sure you're utilizing the proper markdown formatting.
- [x] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices) to be sure you're aligning with our voice and other style best practices.
- [ ] [Preview your deployed changes](https://homeslice.braze.com/docs) to confirm that none of your changes break production. Pay close attention to links and images.
- [x] Tag others as Reviewers as necessary.
- [x] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
