### PR TITLE
remove-feedback

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/android/advanced_use_cases/localization.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/advanced_use_cases/localization.md
@@ -6,7 +6,7 @@ search_rank: 5
 ---
 ## Localization
 
-Localization is supported within the Braze Android SDK. In addition to English, Braze supports 29 languages in our built-in SDK messages. These pertain to the default messages displayed in applications integrated with Braze, such as places in the app that request feedback ("Please enter a feedback message") or when there are connectivity issues ("Cannot establish network connection. Please try again later.") See below for a full list of messages (strings). If the phone language is set to one of the supported languages, any of the Braze default strings triggered within an integrated application will automatically appear in that language.
+Localization is supported within the Braze Android SDK. In addition to English, Braze supports 29 languages in our built-in SDK messages. These pertain to the default messages displayed in applications integrated with Braze, such as places in the app when there are connectivity issues ("Cannot establish network connection. Please try again later.") See below for a full list of messages (strings). If the phone language is set to one of the supported languages, any of the Braze default strings triggered within an integrated application will automatically appear in that language.
 
 ### Languages Supported
 

--- a/_docs/_developer_guide/platform_integration_guides/android/customer_feedback.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/customer_feedback.md
@@ -5,6 +5,11 @@ page_order: 7
 search_rank: 5
 hidden: true
 ---
+
+{% alert Update %}
+Customer Feedback is no longer supported. [Learn more about this and other deprecated features here]({{ site.baseurl }}/help/release_notes/deprecations/#feedback).
+{% endalert %}
+
 # Customer Feedback
 
 {% alert warning %}

--- a/_docs/_developer_guide/platform_integration_guides/android/customer_feedback.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/customer_feedback.md
@@ -3,6 +3,7 @@ nav_title: Customer Feedback
 platform: Android
 page_order: 7
 search_rank: 5
+hidden: true
 ---
 # Customer Feedback
 

--- a/_docs/_developer_guide/platform_integration_guides/android/news_feed/integration_overview.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/news_feed/integration_overview.md
@@ -7,7 +7,7 @@ platform: Android
 
 # News Feed Integration Overview
 
-In Android, the News Feed and feedback form are implemented as [Fragments][2] that are available in the Braze Android UI project. View [Google's documentation on Fragments][3] for information on how to add a Fragment to an Activity.
+In Android, the News Feed is implemented as a [Fragment][2] that are available in the Braze Android UI project. View [Google's documentation on Fragments][3] for information on how to add a Fragment to an Activity.
 
 >  The Android UI Fragments do not automatically track session analytics. To ensure that sessions are tracked correctly, you should call `IAppboy.openSession()` when your app is opened (learn more about [tracking user sessions][4]).
 

--- a/_docs/_developer_guide/platform_integration_guides/fireos/advanced_use_cases/localization.md
+++ b/_docs/_developer_guide/platform_integration_guides/fireos/advanced_use_cases/localization.md
@@ -6,7 +6,7 @@ search_rank: 4
 ---
 ## Localization
 
-Localization is supported within the Braze Android SDK. In addition to English, Braze supports 29 languages in our built-in SDK messages. These pertain to the default messages displayed in applications integrated with Braze, such as places in the app that request feedback ("Please enter a feedback message") or when there are connectivity issues ("Cannot establish network connection. Please try again later.") See below for a full list of messages (strings). If the phone language is set to one of the supported languages, any of the Braze default strings triggered within an integrated application will automatically appear in that language.
+Localization is supported within the Braze Android SDK. In addition to English, Braze supports 29 languages in our built-in SDK messages. These pertain to the default messages displayed in applications integrated with Braze, such as places in the app when there are connectivity issues ("Cannot establish network connection. Please try again later.") See below for a full list of messages (strings). If the phone language is set to one of the supported languages, any of the Braze default strings triggered within an integrated application will automatically appear in that language.
 
 ### Languages Supported
 

--- a/_docs/_developer_guide/platform_integration_guides/fireos/customer_feedback.md
+++ b/_docs/_developer_guide/platform_integration_guides/fireos/customer_feedback.md
@@ -3,6 +3,7 @@ nav_title: Customer Feedback
 platform: FireOS
 page_order: 5
 search_rank: 4
+hidden: true
 ---
 # Customer Feedback
 

--- a/_docs/_developer_guide/platform_integration_guides/fireos/customer_feedback.md
+++ b/_docs/_developer_guide/platform_integration_guides/fireos/customer_feedback.md
@@ -5,9 +5,12 @@ page_order: 5
 search_rank: 4
 hidden: true
 ---
-# Customer Feedback
 
-_The Customer Feedback module has been deprecated and is not available to new integrations._
+{% alert Update %}
+Customer Feedback is no longer supported. [Learn more about this and other deprecated features here]({{ site.baseurl }}/help/release_notes/deprecations/#feedback).
+{% endalert %}
+
+# Customer Feedback
 
 The Braze feedback form allows users to submit feedback about your app that is immediately sent to your company's dashboard.
 

--- a/_docs/_developer_guide/platform_integration_guides/ios/advanced_use_cases/localization.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/advanced_use_cases/localization.md
@@ -6,7 +6,7 @@ search_rank: 5
 ---
 ## Localization
 
-Localization is supported in version 2.5+ of the Braze iOS SDK. In addition to English, Braze supports 29 languages in our built-in SDK messages. These pertain to the default messages displayed in applications integrated with Braze, such as places in the app that request feedback ("Please enter a feedback message") or when there are connectivity issues ("Cannot establish network connection. Please try again later.") See below for a full list of messages (strings). If the phone language is set to one of the supported languages, any of the Braze default strings triggered within an integrated application will automatically appear in that language.
+Localization is supported in version 2.5+ of the Braze iOS SDK. In addition to English, Braze supports 29 languages in our built-in SDK messages. These pertain to the default messages displayed in applications integrated with Braze, such as places in the app when there are connectivity issues ("Cannot establish network connection. Please try again later.") See below for a full list of messages (strings). If the phone language is set to one of the supported languages, any of the Braze default strings triggered within an integrated application will automatically appear in that language.
 
 ### Languages Supported
 1. Arabic

--- a/_docs/_developer_guide/platform_integration_guides/ios/customer_feedback.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/customer_feedback.md
@@ -5,9 +5,11 @@ page_order: 7
 search_rank: 5
 hidden: true
 ---
-# Customer Feedback
+{% alert Update %}
+Customer Feedback is no longer supported. [Learn more about this and other deprecated features here]({{ site.baseurl }}/help/release_notes/deprecations/#feedback).
+{% endalert %}
 
-_The Customer Feedback module has been deprecated and is not available to new integrations._
+# Customer Feedback
 
 The Braze feedback form allows users to submit feedback about your app that is immediately sent to your company's dashboard.
 

--- a/_docs/_developer_guide/platform_integration_guides/ios/customer_feedback.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/customer_feedback.md
@@ -3,6 +3,7 @@ nav_title: Customer Feedback
 platform: iOS
 page_order: 7
 search_rank: 5
+hidden: true
 ---
 # Customer Feedback
 

--- a/_docs/_developer_guide/platform_integration_guides/react_native/android_and_fireos/customer_feedback.md
+++ b/_docs/_developer_guide/platform_integration_guides/react_native/android_and_fireos/customer_feedback.md
@@ -5,9 +5,12 @@ subplatform: Android and FireOS
 page_order: 5
 hidden: true
 ---
-# Customer Feedback
 
-_The Customer Feedback module has been deprecated and is not available to new integrations._
+{% alert Update %}
+Customer Feedback is no longer supported. [Learn more about this and other deprecated features here]({{ site.baseurl }}/help/release_notes/deprecations/#feedback).
+{% endalert %}
+
+# Customer Feedback
 
 See [the Android integration instructions][1] for information on how to integrate the feedback form into your React Native Android app.
 

--- a/_docs/_developer_guide/platform_integration_guides/react_native/android_and_fireos/customer_feedback.md
+++ b/_docs/_developer_guide/platform_integration_guides/react_native/android_and_fireos/customer_feedback.md
@@ -3,6 +3,7 @@ nav_title: Customer Feedback
 platform: React Native
 subplatform: Android and FireOS
 page_order: 5
+hidden: true
 ---
 # Customer Feedback
 

--- a/_docs/_developer_guide/platform_integration_guides/react_native/ios/customer_feedback.md
+++ b/_docs/_developer_guide/platform_integration_guides/react_native/ios/customer_feedback.md
@@ -5,9 +5,12 @@ subplatform: iOS
 page_order: 5
 hidden: true
 ---
-# Customer Feedback
 
-_The Customer Feedback module has been deprecated and is not available to new integrations._
+{% alert Update %}
+Customer Feedback is no longer supported. [Learn more about this and other deprecated features here]({{ site.baseurl }}/help/release_notes/deprecations/#feedback).
+{% endalert %}
+
+# Customer Feedback
 
 See [the iOS integration instructions][1] for information on how to integrate the feedback form into your React Native iOS app. Alternatively, the React plugin provides a `launchFeedback` method that will launch a modal feedback element over your application.
 

--- a/_docs/_developer_guide/platform_integration_guides/react_native/ios/customer_feedback.md
+++ b/_docs/_developer_guide/platform_integration_guides/react_native/ios/customer_feedback.md
@@ -3,6 +3,7 @@ nav_title: Customer Feedback
 platform: React Native
 subplatform: iOS
 page_order: 5
+hidden: true
 ---
 # Customer Feedback
 

--- a/_docs/_developer_guide/platform_integration_guides/unity/news_feed.md
+++ b/_docs/_developer_guide/platform_integration_guides/unity/news_feed.md
@@ -13,7 +13,7 @@ page_order: 4
 
 ## Retrieving the News Feed
 
-To retrieve the News Feed from BRaze, call either of the following methods:
+To retrieve the News Feed from Braze, call either of the following methods:
 
 - [`AppboyBinding.RequestFeedRefresh()`][2] requests a News Feed refresh directly from BRaze's servers
 - [`AppboyBinding.RequestFeedRefreshFromCache()`][3] pulls the locally-stored News Feed

--- a/_docs/_developer_guide/platform_integration_guides/xamarin/android_and_fireos/customer_feedback.md
+++ b/_docs/_developer_guide/platform_integration_guides/xamarin/android_and_fireos/customer_feedback.md
@@ -5,9 +5,11 @@ subplatform: Android and FireOS
 page_order: 5
 hidden: true
 ---
-# Customer Feedback
+{% alert Update %}
+Customer Feedback is no longer supported. [Learn more about this and other deprecated features here]({{ site.baseurl }}/help/release_notes/deprecations/#feedback).
+{% endalert %}
 
-_The Customer Feedback module has been deprecated and is not available to new integrations._
+# Customer Feedback
 
 See [the Android integration instructions][1] for information on how to integrate the feedback form into your Xamarin Android app.  Furthermore, you can look at the [sample application][2] for implementation samples.
 

--- a/_docs/_developer_guide/platform_integration_guides/xamarin/android_and_fireos/customer_feedback.md
+++ b/_docs/_developer_guide/platform_integration_guides/xamarin/android_and_fireos/customer_feedback.md
@@ -3,6 +3,7 @@ nav_title: Customer Feedback
 platform: Xamarin
 subplatform: Android and FireOS
 page_order: 5
+hidden: true
 ---
 # Customer Feedback
 

--- a/_docs/_developer_guide/platform_integration_guides/xamarin/ios/customer_feedback.md
+++ b/_docs/_developer_guide/platform_integration_guides/xamarin/ios/customer_feedback.md
@@ -5,9 +5,11 @@ subplatform: iOS
 page_order: 5
 hidden: true
 ---
-# Customer Feedback
+{% alert Update %}
+Customer Feedback is no longer supported. [Learn more about this and other deprecated features here]({{ site.baseurl }}/help/release_notes/deprecations/#feedback).
+{% endalert %}
 
-_The Customer Feedback module has been deprecated and is not available to new integrations._
+# Customer Feedback
 
 See [the iOS integration instructions][1] for information on how to integrate the feedback form into your Xamarin iOS app.  Furthermore, you can look at the [sample application][2] for implementation samples.
 

--- a/_docs/_developer_guide/platform_integration_guides/xamarin/ios/customer_feedback.md
+++ b/_docs/_developer_guide/platform_integration_guides/xamarin/ios/customer_feedback.md
@@ -3,6 +3,7 @@ nav_title: Customer Feedback
 platform: Xamarin
 subplatform: iOS
 page_order: 5
+hidden: true
 ---
 # Customer Feedback
 

--- a/_docs/_developer_guide/platform_wide/platform_features.md
+++ b/_docs/_developer_guide/platform_wide/platform_features.md
@@ -18,7 +18,7 @@ The Braze SDKs can be integrated into your mobile and web applications to provid
 
 ## Dashboard/UI
 
-The dashboard controls all of the data and interactions at the heart of the Braze platform. Marketers can use the site to manage notifications, setup targeted messaging campaigns, and view analytics or feedback. Developers can use the dashboard to manage settings for integrating apps, such as API keys and push notification credentials.
+The dashboard controls all of the data and interactions at the heart of the Braze platform. Marketers can use the site to manage notifications, setup targeted messaging campaigns, and view analytics. Developers can use the dashboard to manage settings for integrating apps, such as API keys and push notification credentials.
 
 ## Data API
 
@@ -53,7 +53,7 @@ When your app opens, the Braze SDK automatically pulls down the user's News Feed
 
 ### Push Notifications {#platform-features-push}
 
-Braze supports the Apple Push Notification Service (APNs) for iOS and Firebase Cloud Messaging (FCM) for Android. Push notifications can be triggered by the publication of messaging campaigns, news items, and replying to user feedback.
+Braze supports the Apple Push Notification Service (APNs) for iOS and Firebase Cloud Messaging (FCM) for Android. Push notifications can be triggered by the publication of messaging campaigns, and news items.
 
 ![Example Push Dashboard][8]
 
@@ -74,15 +74,6 @@ Send your users rich HTML messages by adding your existing HTML templates or or 
 Braze's webhooks allow you to trigger non-app actions such as SMS text message delivery. You can use webhooks to provide other systems and applications with real-time information. The flexibility of this feature allows you to send information to any endpoint.
 
 ![Webhooks][22]
-
-### Feedback {#platform-features-feedback}
-
- The Braze SDK provides a feedback widget that can be added to your app to allow users to leave feedback. Feedback is managed on the dashboard, where you can add internal notes and respond to users via multiple messaging channels. We show the user's Braze profile side-by-side with their feedback so you can easily see the user's device, OS version, app version, and behavioral data. This minimizes the work your support team has to do to understand technical issues.
-
- {% alert warning %}
-This feature is [set to be deprecated]({{ site.baseurl }}/help/release_notes/deprecations/#feedback) on July 1, 2019.
-  {% endalert %}
-
 
 
 

--- a/_docs/_partners/technology_partners/data_and_infrastructure_agility/customer_data_platform/segment.md
+++ b/_docs/_partners/technology_partners/data_and_infrastructure_agility/customer_data_platform/segment.md
@@ -72,7 +72,7 @@ The server-to-server integration forwards data from Segment to Braze's REST API.
 
 ![Segment's Go Integration][43]
 
-Unlike the side-by-side integration, however, the server-to-server integration does not support any of Braze's UI features, such as in-app messaging, News Feed, Feedback or push notifications.
+Unlike the side-by-side integration, however, the server-to-server integration does not support any of Braze's UI features, such as in-app messaging, News Feed, or push notifications.
 
 ## Getting Started
 

--- a/_docs/_user_guide/administrative/manage_your_braze_users/user_permissions.md
+++ b/_docs/_user_guide/administrative/manage_your_braze_users/user_permissions.md
@@ -46,7 +46,6 @@ You can manage user permissions by group or on an individual basis using the Use
 |Manage Events, Attributes, Purchases|Allows user to edit custom attributes, (users without this capability can still view custom attributes), edit and view properties of custom events, and edit and view properties of products (all under manage app group).|
 |Manage Tags|Allows users to edit or delete tags (under manage app group). You do not need this permission to add tags to campaigns or segments.|
 |Manage Email Settings|Allows user to save email configuration changes (email settings tab under "manage app group").|
-|Manage Feedback|Allows user to access Feedback page.|
 |Manage Teams|Allows user to manage teams which is under "Manage App Group". The ability to select this permission depends on your contract with Braze.|
 
 ## App-by-App User Permissions


### PR DESCRIPTION
# Pull Request/Issue Resolution

**Description of Change:**
Removing all references to feedback feature as we sunsetted it 7/31/19.

**Reason for Change:**
Feature is sunsetted and no longer available to customers. 


Closes #**ISSUE_NUMBER_HERE**

### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Feature Release Date:__)
- [ ] No

> If yes, please note the date of the feature release.


---
---

## PR Checklist
- [ ] Ensure you have completed [our CLA](https://www.braze.com/docs/cla/).
- [ ] Tag @EmilyNecciai as a reviewer when the your work is _done and ready to be reviewed for merge_.
- [ ] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide).
- [ ] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices).
- [ ] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

## ATTENTION: REVIEWERS OF THIS PR
- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Preview all changes in the linked Heroku environment (click `View deployment` button below, then "Docs". A `502` error just means you should refresh until you see the Docs Home page.
---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
