### PR TITLE
Fixes typo in Content Cards code example

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/web/content_cards/integration.md
+++ b/_docs/_developer_guide/platform_integration_guides/web/content_cards/integration.md
@@ -9,10 +9,10 @@ platform: Web
 
 To toggle display of Content Cards through the Braze Web SDK, call:
 
-[`appboy.display.toggleContentCards[();`](https://js.appboycdn.com/web-sdk/latest/doc/module-display.html#.toggleContentCards)
+[`appboy.display.toggleContentCards();`](https://js.appboycdn.com/web-sdk/latest/doc/module-display.html#.toggleContentCards)
 
 
-This will show the Content Cards if they are not shown, and hide them if they are. If no parameters are defined (null), all Content Cards will be shown in a fixed-position sidebar on the right-hand side of the page.
+This method will toggle the visility of the Content Cards. By default, if no arguments are provided, all Content Cards will be shown in a fixed-position sidebar on the right-hand side of the page.
 
 |Parameters | Description |
 |---|---|
@@ -25,8 +25,8 @@ This will show the Content Cards if they are not shown, and hide them if they ar
 
 |Method | Description | Link|
 |---|---|---|
-|`showContentCards`| Display the user's Content Cards. | [JS Docs for showContentCards](https://js.appboycdn.com/web-sdk/latest/doc/module-display.html#.showContentCards)|
-|`hideContentCards`| Hide any Braze content cards currently showing. | [JS Docs for hideContentCards](https://js.appboycdn.com/web-sdk/latest/doc/module-display.html#.hideContentCards)
-|`toggleContentCards`| Display the user's content cards. | [JS Docs for showContentCards](https://js.appboycdn.com/web-sdk/latest/doc/module-display.html#.toggleContentCards)
+|`showContentCards()`| Display the user's Content Cards. | [JS Docs for showContentCards](https://js.appboycdn.com/web-sdk/latest/doc/module-display.html#.showContentCards)|
+|`hideContentCards()`| Hide any Braze content cards currently showing. | [JS Docs for hideContentCards](https://js.appboycdn.com/web-sdk/latest/doc/module-display.html#.hideContentCards)
+|`toggleContentCards()`| Toggle the visibility of the Content Cards. | [JS Docs for showContentCards](https://js.appboycdn.com/web-sdk/latest/doc/module-display.html#.toggleContentCards)
 |`getCachedContentCards()`|Get all currently available cards from the last content cards refresh.| [JS Docs for getCachedContentCards](https://js.appboycdn.com/web-sdk/latest/doc/module-appboy.html#.getCachedContentCards)|
 |`subscribeToContentCardsUpdates(subscriber)`| Subscribe to content cards updates. <br> The subscriber callback will be called whenever content cards are updated. |  [JS Docs for subscribeToContentCardsUpdates](https://js.appboycdn.com/web-sdk/latest/doc/module-appboy.html#.getCachedContentCards)|


### PR DESCRIPTION
1. Code example had an extra square bracket
2. Updated phrasing of toggle method's description
3. Added parentheses for consistency in the table of methods