### PR TITLE
Add Line Break between Alert Header and content

### DIFF
--- a/_plugins/alert_tag.rb
+++ b/_plugins/alert_tag.rb
@@ -14,7 +14,7 @@ module Jekyll
         # converter = site.getConverterImpl(::Jekyll::Converters::Markdown)
         type = converter.convert(@caption).gsub(/<\/?p[^>]*>/, '').chomp
         body = converter.convert(super(context))
-        "<div class='alert alert-#{type}' role='alert'><div class='alert-msg'> <b>#{type}: </b>#{body}</div></div>"
+        "<div class='alert alert-#{type}' role='alert'><div class='alert-msg'> <b>#{type}: </b><br />#{body}</div></div>"
       end
 
     end


### PR DESCRIPTION
# Pull Request/Issue Resolution

**Description of Change:**
> I'm adding a Line Break between Alert Header and content


**Reason for Change:**
> I'm making this change because it will make the alerts easier to read. 


Closes #**ISSUE_NUMBER_HERE**

### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Feature Release Date:__)
- [x] No

> If yes, please note the date of the feature release.


---
---

## PR Checklist
- [ ] Ensure you have completed [our CLA](https://www.braze.com/docs/cla/).
- [ ] Tag @EmilyNecciai as a reviewer when the your work is _done and ready to be reviewed for merge_.
- [ ] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide).
- [ ] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices).
- [ ] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

## ATTENTION: REVIEWERS OF THIS PR
- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Preview all changes in the linked Heroku environment (click `View deployment` button below, then "Docs". A `502` error just means you should refresh until you see the Docs Home page.
---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
