### PR TITLE
Wording Adjustment in Create_Send

### DIFF
--- a/_docs/_hidden/private_betas/create_send.md
+++ b/_docs/_hidden/private_betas/create_send.md
@@ -17,7 +17,7 @@ _For example, you might want to send an order confirmation to a customer that ju
 
 _Another example is ensuring that user attributes needed for campaign segmentation are processed before the campaign is sent. You might have a segment on your api triggered campaign that references an attribute value like gender, which is provided by the user during the registration process. If the attribute isn't updated on the user's profile before the campaign segmentation is evaluated, the user will not get the campaign._
 
-Use this endpoint to guarantee that:
+Use the Attriburtes Object in this endpoint to guarantee that:
 
 - Users are created before a request to the `campaigns/trigger/send` endpoint is processed.
 - User attributes are updated before a request to the `campaign/trigger/send` endpoint is processed.


### PR DESCRIPTION
# Pull Request/Issue Resolution

**Description of Change:**
> I'm changing some wording around Attributes Objects and Endpoints for clarify some informaiton.


**Reason for Change:**
> I'm making this change because I mistakenly called an Object an Endpoint in my initial edits.


### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Feature Release Date:__)
- [x] No

> If yes, please note the date of the feature release.


---
---

## PR Checklist
- [ ] Ensure you have completed [our CLA](https://www.braze.com/docs/cla/).
- [ ] Tag @EmilyNecciai as a reviewer when the your work is _done and ready to be reviewed for merge_.
- [ ] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide).
- [ ] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices).
- [ ] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

## ATTENTION: REVIEWERS OF THIS PR
- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Preview all changes in the linked Heroku environment (click `View deployment` button below, then "Docs". A `502` error just means you should refresh until you see the Docs Home page.
---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
