### PR TITLE
Update FireOS and Android docs for default location collection being disabled.

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/android/advanced_use_cases/locations_and_geofences.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/advanced_use_cases/locations_and_geofences.md
@@ -70,7 +70,7 @@ To enable Braze location collection, update your `appboy.xml` file to include `c
 Starting with Braze Android SDK version 3.6.0 Braze location collection is disabled by default.
 {% endalert %}
 
-Braze geofences are enabled if location collection is enabled. If you would like to opt-out of our default location collection but still want to use geofences, it can be enabled selectively by setting the value of key `com_appboy_geofences_enabled` to true in `appboy.xml`, independent to the value of `com_appboy_enable_location_collection`. 
+Braze geofences are enabled if Braze location collection is enabled. If you would like to opt-out of our default location collection but still want to use geofences, it can be enabled selectively by setting the value of key `com_appboy_geofences_enabled` to true in `appboy.xml`, independently of the value of `com_appboy_enable_location_collection`. 
 
 ```xml
 <bool name="com_appboy_geofences_enabled">true</bool>

--- a/_docs/_developer_guide/platform_integration_guides/android/advanced_use_cases/locations_and_geofences.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/advanced_use_cases/locations_and_geofences.md
@@ -70,6 +70,12 @@ To enable Braze location collection, update your `appboy.xml` file to include `c
 Starting with Braze Android SDK version 3.6.0 Braze location collection is disabled by default.
 {% endalert %}
 
+Braze geofences are enabled if location collection is enabled. If you would like to opt-out of our default location collection but still want to use geofences, it can be enabled selectively by setting the value of key `com_appboy_geofences_enabled` to true in `appboy.xml`, independent to the value of `com_appboy_enable_location_collection`. 
+
+```xml
+<bool name="com_appboy_geofences_enabled">true</bool>
+```
+
 ### Step 4: Obtain Location Permissions from the End User
 
 For Android M and higher versions, you must request location permissions from the end user before gathering location information or registering geofences.

--- a/_docs/_developer_guide/platform_integration_guides/android/advanced_use_cases/locations_and_geofences.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/advanced_use_cases/locations_and_geofences.md
@@ -13,7 +13,7 @@ To support geofences for Android:
 
 1. Your integration must support background push notifications.
 
-2. Braze location collection must not be disabled.
+2. Braze geofences or location collection must be enabled.
 
 ### Step 1: Update build.gradle
 

--- a/_docs/_developer_guide/platform_integration_guides/android/analytics/location_tracking.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/analytics/location_tracking.md
@@ -40,5 +40,5 @@ Appboy.getInstance(YOUR_ACTIVITY.this).getCurrentUser().setLastKnownLocation(LAT
 See [our Android SDK repo][3] for an implementation example of the above in our Droidboy sample app and [here in our Javadocs][4] for more information on the `setLastKnownLocation` method.
 
 [1]: http://developer.android.com/guide/topics/location/strategies.html
-[3]: https://github.com/Appboy/appboy-android-sdk/blob/master/droidboy/src/main/java/com/appboy/sample/PreferencesActivity.java#L129
+[3]: https://github.com/Appboy/appboy-android-sdk/blob/master/droidboy/src/main/java/com/appboy/sample/PreferencesActivity.java#L146
 [4]: https://appboy.github.io/appboy-android-sdk/javadocs/com/appboy/AppboyUser.html#setLastKnownLocation-double-double-java.lang.Double-java.lang.Double-

--- a/_docs/_developer_guide/platform_integration_guides/android/analytics/location_tracking.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/analytics/location_tracking.md
@@ -37,8 +37,7 @@ Then you can manually log single location data points via the setLastKnownLocati
 Appboy.getInstance(YOUR_ACTIVITY.this).getCurrentUser().setLastKnownLocation(LATITUDE_DOUBLE_VALUE, LONGITUDE_DOUBLE_VALUE, ALTITUDE_DOUBLE_VALUE, ACCURACY_DOUBLE_VALUE);
 ```
 
-See [our Android SDK repo][3] for an implementation example of the above in our Droidboy sample app and [here in our Javadocs][4] for more information on the `setLastKnownLocation` method.
+See [here in our Javadocs][4] for more information on the `setLastKnownLocation` method.
 
 [1]: http://developer.android.com/guide/topics/location/strategies.html
-[3]: https://github.com/Appboy/appboy-android-sdk/blob/master/droidboy/src/main/java/com/appboy/sample/PreferencesActivity.java#L146
 [4]: https://appboy.github.io/appboy-android-sdk/javadocs/com/appboy/AppboyUser.html#setLastKnownLocation-double-double-java.lang.Double-java.lang.Double-

--- a/_docs/_developer_guide/platform_integration_guides/fireos/advanced_use_cases/locations_and_geofences.md
+++ b/_docs/_developer_guide/platform_integration_guides/fireos/advanced_use_cases/locations_and_geofences.md
@@ -13,9 +13,7 @@ To support geofences for Android:
 
 1. Your integration must support background push notifications.
 
-2. Braze location collection must not be disabled.
-
->  Braze location collection is enabled by default. To verify your location collection status on Android, ensure that `com_appboy_disable_location_collection` is not set to `true` in your `appboy.xml`.
+2. Braze geofences or location collection must be enabled.
 
 ### Step 1: Update build.gradle
 
@@ -57,7 +55,19 @@ declaration is also required:
 ```
 {% endalert %}
 
-### Step 3: Obtain Location Permissions from the End User
+### Step 3: Enable Braze Location Collection
+
+To enable Braze location collection, update your `appboy.xml` file to include `com_appboy_enable_location_collection` and ensure its value is set to true.
+
+```xml
+<bool name="com_appboy_enable_location_collection">true</bool>
+```
+
+{% alert important %}
+Starting with Braze Android SDK version 3.6.0 Braze location collection is disabled by default.
+{% endalert %}
+
+### Step 4: Obtain Location Permissions from the End User
 
 For Android M and higher versions, you must request location permissions from the end user before gathering location information or registering geofences.
 
@@ -71,7 +81,7 @@ This will cause the SDK to request geofences from Braze's servers and initialize
 
 See [`RuntimePermissionUtils.java`][4] in our sample application for an example implementation.
 
-### Step 4: Enable Geofences on the Dashboard
+### Step 5: Enable Geofences on the Dashboard
 
 Android only allows up to 100 geofences to be stored for a given app. Braze's Locations product will use up to 20 of these geofence slots if available. To prevent accidental or unwanted disruption to other geofence-related functionality in your app, location geofences must be enabled for individual Apps on the Dashboard.
 

--- a/_docs/_developer_guide/platform_integration_guides/fireos/advanced_use_cases/locations_and_geofences.md
+++ b/_docs/_developer_guide/platform_integration_guides/fireos/advanced_use_cases/locations_and_geofences.md
@@ -67,7 +67,7 @@ To enable Braze location collection, update your `appboy.xml` file to include `c
 Starting with Braze Android SDK version 3.6.0 Braze location collection is disabled by default.
 {% endalert %}
 
-Braze geofences are enabled if location collection is enabled. If you would like to opt-out of our default location collection but still want to use geofences, it can be enabled selectively by setting the value of key `com_appboy_geofences_enabled` to true in `appboy.xml`, independent to the value of `com_appboy_enable_location_collection`. 
+Braze geofences are enabled if Braze location collection is enabled. If you would like to opt-out of our default location collection but still want to use geofences, it can be enabled selectively by setting the value of key `com_appboy_geofences_enabled` to true in `appboy.xml`, independently of the value of `com_appboy_enable_location_collection`. 
 
 ```xml
 <bool name="com_appboy_geofences_enabled">true</bool>

--- a/_docs/_developer_guide/platform_integration_guides/fireos/advanced_use_cases/locations_and_geofences.md
+++ b/_docs/_developer_guide/platform_integration_guides/fireos/advanced_use_cases/locations_and_geofences.md
@@ -67,6 +67,12 @@ To enable Braze location collection, update your `appboy.xml` file to include `c
 Starting with Braze Android SDK version 3.6.0 Braze location collection is disabled by default.
 {% endalert %}
 
+Braze geofences are enabled if location collection is enabled. If you would like to opt-out of our default location collection but still want to use geofences, it can be enabled selectively by setting the value of key `com_appboy_geofences_enabled` to true in `appboy.xml`, independent to the value of `com_appboy_enable_location_collection`. 
+
+```xml
+<bool name="com_appboy_geofences_enabled">true</bool>
+```
+
 ### Step 4: Obtain Location Permissions from the End User
 
 For Android M and higher versions, you must request location permissions from the end user before gathering location information or registering geofences.

--- a/_docs/_developer_guide/platform_integration_guides/fireos/analytics/location_tracking.md
+++ b/_docs/_developer_guide/platform_integration_guides/fireos/analytics/location_tracking.md
@@ -17,16 +17,18 @@ Or:
 <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 ```
 
-> With the release of Android M, Android switched from an install-time to a runtime permissions model. To enable location tracking on devices running M and above, the app must explicitly receive permission to use location from the user (Braze will not do this). Once location permissions are obtained, Braze will automatically begin tracking location on the next session start. Devices running earlier versions of Android only require location permissions to be declared in the `AndroidManifest.xml`. For more information, visit Android's [permission documentation][2].
+{% alert important %}
+With the release of Android M, Android switched from an install-time to a runtime permissions model. To enable location tracking on devices running M and above, the app must explicitly receive permission to use location from the user (Braze will not do this). Once location permissions are obtained, Braze will automatically begin tracking location on the next session start, if location collection is enabled in `appboy.xml`. Devices running earlier versions of Android only require location permissions to be declared in the `AndroidManifest.xml`. For more information, visit Android's [permission documentation](https://developer.android.com/training/permissions/index.html).
+{% endalert %}
 
-> `ACCESS_FINE_LOCATION` includes GPS data in reporting user location while `ACCESS_COARSE_LOCATION` includes data from the most battery-efficient non-GPS provider available (e.g. the network). Coarse location location will likely be sufficient for the majority of location data use-cases; however, under the runtime permissions model, receiving location permission from the user implicitly authorizes the collection of fine location data. You can read more about the differences between these location permissions and how you ought to utilize them [here][1].
+`ACCESS_FINE_LOCATION` includes GPS data in reporting user location while `ACCESS_COARSE_LOCATION` includes data from the most battery-efficient non-GPS provider available (e.g. the network). Coarse location location will likely be sufficient for the majority of location data use-cases; however, under the runtime permissions model, receiving location permission from the user implicitly authorizes the collection of fine location data. You can read more about the differences between these location permissions and how you ought to utilize them [here][1].
 
 ### Disabling Automatic Location Tracking
 
-To disable automatic location tracking, set `com_appboy_disable_location_collection` to true in `appboy.xml`:
+To disable automatic location tracking, set `com_appboy_enable_location_collection` to false in `appboy.xml`:
 
 ```xml
-<bool name="com_appboy_disable_location_collection">true</bool>
+<bool name="com_appboy_enable_location_collection">false</bool>
 ```
 
 Then you can manually log single location data points via the setLastKnownLocation() method on `AppboyUser` like this:
@@ -38,6 +40,5 @@ Appboy.getInstance(YOUR_ACTIVITY.this).getCurrentUser().setLastKnownLocation(LAT
 See [here][3] for an implementation example of the above in our Droidboy sample app and [here in our Javadocs][4] for more information on the `setLastKnownLocation` method.
 
 [1]: http://developer.android.com/guide/topics/location/strategies.html
-[2]: https://developer.android.com/training/permissions/index.html
-[3]: https://github.com/Appboy/appboy-android-sdk/blob/master/droidboy/src/main/java/com/appboy/sample/PreferencesActivity.java#L129
+[3]: https://github.com/Appboy/appboy-android-sdk/blob/master/droidboy/src/main/java/com/appboy/sample/PreferencesActivity.java#L146
 [4]: https://appboy.github.io/appboy-android-sdk/javadocs/com/appboy/AppboyUser.html#setLastKnownLocation-double-double-java.lang.Double-java.lang.Double-

--- a/_docs/_developer_guide/platform_integration_guides/fireos/analytics/location_tracking.md
+++ b/_docs/_developer_guide/platform_integration_guides/fireos/analytics/location_tracking.md
@@ -37,8 +37,7 @@ Then you can manually log single location data points via the setLastKnownLocati
 Appboy.getInstance(YOUR_ACTIVITY.this).getCurrentUser().setLastKnownLocation(LATITUDE_DOUBLE_VALUE, LONGITUDE_DOUBLE_VALUE, ALTITUDE_DOUBLE_VALUE, ACCURACY_DOUBLE_VALUE);
 ```
 
-See [here][3] for an implementation example of the above in our Droidboy sample app and [here in our Javadocs][4] for more information on the `setLastKnownLocation` method.
+See [here in our Javadocs][4] for more information on the `setLastKnownLocation` method.
 
 [1]: http://developer.android.com/guide/topics/location/strategies.html
-[3]: https://github.com/Appboy/appboy-android-sdk/blob/master/droidboy/src/main/java/com/appboy/sample/PreferencesActivity.java#L146
 [4]: https://appboy.github.io/appboy-android-sdk/javadocs/com/appboy/AppboyUser.html#setLastKnownLocation-double-double-java.lang.Double-java.lang.Double-

--- a/_docs/_user_guide/engagement_tools/locations_and_geofences/mobile_integrations.md
+++ b/_docs/_user_guide/engagement_tools/locations_and_geofences/mobile_integrations.md
@@ -11,9 +11,11 @@ Geofence-triggered campaigns are available on iOS and Android. To support geofen
 
 1. Your integration must support background push notifications.
 
-2. Braze location collection must not be disabled.
+2. Braze geofences or location collection must be enabled.
 
->  Braze location collection is enabled by default. To verify your location collection status on Android, ensure that `com_appboy_disable_location_collection` is not set to `true` in your `appboy.xml`.
+{% alert important %}
+Starting with Braze SDK version 3.6.0 Braze location collection is disabled by default. To verify location collection is enabled on Android, ensure that `com_appboy_enable_location_collection` is set to `true` in your `appboy.xml`.
+{% endalert %}
 
 ## Geofence Configuration
 


### PR DESCRIPTION
# Pull Request/Issue Resolution
https://jira.braze.com/browse/PC-1271

**Description of Change:**
> I'm changing https://jira.braze.com/browse/PC-1271


**Reason for Change:**
> Starting with Braze Android SDK version 3.6.0 Braze location collection is disabled by default. Updating documentation to reflect those changes.


Closes https://jira.braze.com/browse/PC-1271

### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Feature Release Date:__)
- [x] No

> If yes, please note the date of the feature release.


---
---

## PR Checklist
- [x] Ensure you have completed [our CLA](https://www.braze.com/docs/cla/).
- [x] Tag @EmilyNecciai as a reviewer when the your work is _done and ready to be reviewed for merge_.
- [x] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide).
- [x] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices).
- [x] Tag others as Reviewers as necessary.
- [x] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

## ATTENTION: REVIEWERS OF THIS PR
- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Preview all changes in the linked Heroku environment (click `View deployment` button below, then "Docs". A `502` error just means you should refresh until you see the Docs Home page.
---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
