### PR TITLE
Add to Android docs Content Cards methods.

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/android/content_cards/data_models.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/content_cards/data_models.md
@@ -5,13 +5,13 @@ search_rank: 5
 platform: Android
 ---
 
-## Content Cards Data Model
+# Content Cards Data Model
 The Content Cards data model is available in the Android SDK.
 
-### Card Types {#card-types-for-android}
+## Card Types {#card-types-for-android}
 Braze has 3 unique Content Cards card types which share a base model. Each card type also has additional card-specific properties which are listed below.
 
-#### Base Card {#base-card-for-android}
+### Base Card {#base-card-for-android}
 
 The [Base Card][29] model provides foundational behavior for all cards.  
 
@@ -27,7 +27,7 @@ The [Base Card][29] model provides foundational behavior for all cards.
 |`getIsRemoved()` | Returns a boolean that reflects whether the end user has dismissed this card.|
 |`getIsDismissible()`  | Returns a boolean that reflects whether the card is pinned.|
 
-#### Banner Image Card {#banner-image-card-for-android}
+### Banner Image Card {#banner-image-card-for-android}
 [Banner Image Cards][30] are clickable full-sized images. In addition to the base card properties:
 
 |Property | Description |
@@ -36,7 +36,7 @@ The [Base Card][29] model provides foundational behavior for all cards.
 |`getUrl()` | Returns the URL that will be opened after the card is clicked. It can be a http(s) URL or a protocol URL.|
 |`getDomain()` | Returns link text for the property URL.|
 
-#### Captioned Image Card {#captioned-image-card-for-android}
+### Captioned Image Card {#captioned-image-card-for-android}
 [Captioned Image Cards][31] are clickable full-sized images with accompanying descriptive text. In addition to the base card properties:
 
 |Property | Description |
@@ -47,7 +47,7 @@ The [Base Card][29] model provides foundational behavior for all cards.
 |`getUrl()` | Returns the URL that will be opened after the card is clicked. It can be a http(s) URL or a protocol URL.
 |`getDomain()` | Returns the link text for the property URL.
 
-#### Classic Card {#text-Announcement-card-for-android}
+### Classic Card {#text-Announcement-card-for-android}
 [Text Announcement Cards][32] are clickable cards containing descriptive text. In addition to the base card properties:
 
 |Property | Description |
@@ -57,7 +57,7 @@ The [Base Card][29] model provides foundational behavior for all cards.
 |`getUrl()` | Returns the URL that will be opened after the card is clicked. It can be a http(s) URL or a protocol URL.
 |`getDomain()` | Returns the link text for the property URL.
 
-### Card Analytics Methods
+## Card Analytics Methods
 All `Card` data model objects offer the following analytics methods for logging user events to Braze servers.
 
 |Method | Description |

--- a/_docs/_developer_guide/platform_integration_guides/android/content_cards/data_models.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/content_cards/data_models.md
@@ -57,7 +57,8 @@ The [Base Card][29] model provides foundational behavior for all cards.
 |`getUrl()` | Returns the URL that will be opened after the card is clicked. It can be a http(s) URL or a protocol URL.
 |`getDomain()` | Returns the link text for the property URL.
 
-### Card Methods
+### Card Analytics Methods
+All `Card` data model objects offer the following analytics methods for logging user events to Braze servers.
 
 |Method | Description |
 |---|---|

--- a/_docs/_developer_guide/platform_integration_guides/android/content_cards/data_models.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/content_cards/data_models.md
@@ -5,10 +5,13 @@ search_rank: 5
 platform: Android
 ---
 
-## Card Types {#card-types-for-android}
+## Content Cards Data Model
+The Content Cards data model is available in the Android SDK.
+
+### Card Types {#card-types-for-android}
 Braze has 3 unique Content Cards card types which share a base model. Each card type also has additional card-specific properties which are listed below.
 
-### Base Card {#base-card-for-android}
+#### Base Card {#base-card-for-android}
 
 The [Base Card][29] model provides foundational behavior for all cards.  
 
@@ -24,7 +27,7 @@ The [Base Card][29] model provides foundational behavior for all cards.
 |`getIsRemoved()` | Returns a boolean that reflects whether the end user has dismissed this card.|
 |`getIsDismissible()`  | Returns a boolean that reflects whether the card is pinned.|
 
-### Banner Image Card {#banner-image-card-for-android}
+#### Banner Image Card {#banner-image-card-for-android}
 [Banner Image Cards][30] are clickable full-sized images. In addition to the base card properties:
 
 |Property | Description |
@@ -33,7 +36,7 @@ The [Base Card][29] model provides foundational behavior for all cards.
 |`getUrl()` | Returns the URL that will be opened after the card is clicked. It can be a http(s) URL or a protocol URL.|
 |`getDomain()` | Returns link text for the property URL.|
 
-### Captioned Image Card {#captioned-image-card-for-android}
+#### Captioned Image Card {#captioned-image-card-for-android}
 [Captioned Image Cards][31] are clickable full-sized images with accompanying descriptive text. In addition to the base card properties:
 
 |Property | Description |
@@ -44,7 +47,7 @@ The [Base Card][29] model provides foundational behavior for all cards.
 |`getUrl()` | Returns the URL that will be opened after the card is clicked. It can be a http(s) URL or a protocol URL.
 |`getDomain()` | Returns the link text for the property URL.
 
-### Classic Card {#text-Announcement-card-for-android}
+#### Classic Card {#text-Announcement-card-for-android}
 [Text Announcement Cards][32] are clickable cards containing descriptive text. In addition to the base card properties:
 
 |Property | Description |
@@ -53,6 +56,14 @@ The [Base Card][29] model provides foundational behavior for all cards.
 |`getDescription()` | Returns the body text for the card.
 |`getUrl()` | Returns the URL that will be opened after the card is clicked. It can be a http(s) URL or a protocol URL.
 |`getDomain()` | Returns the link text for the property URL.
+
+### Card Methods
+
+|Method | Description |
+|---|---|
+|`logImpression()` | Manually log an impression to Braze for a particular card.
+|`logClick()` | Manually log a click to Braze for a particular card. 
+|`setIsDismissed()` | Manually log a dismissal to Braze for a particular card. If a card is already marked as dismissed, it cannot be marked as dismissed again.
 
 [1]:{% image_buster /assets/img_archive/contentcard.png %}
 [2]: http://developer.android.com/guide/components/fragments.html


### PR DESCRIPTION
# Pull Request/Issue Resolution
https://jira.braze.com/browse/PC-1249

**Description of Change:**
> Adding to docs Android SDK Content Cards methods


**Reason for Change:**
> No docs present to highlight different methods present for Content Cards.


Closes https://jira.braze.com/browse/PC-1249

### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Feature Release Date:__)
- [x] No

> If yes, please note the date of the feature release.


---
---

## PR Checklist
- [x] Ensure you have completed [our CLA](https://www.braze.com/docs/cla/).
- [x] Tag @EmilyNecciai as a reviewer when the your work is _done and ready to be reviewed for merge_.
- [x] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide).
- [x] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices).
- [x] Tag others as Reviewers as necessary.
- [x] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

## ATTENTION: REVIEWERS OF THIS PR
- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Preview all changes in the linked Heroku environment (click `View deployment` button below, then "Docs". A `502` error just means you should refresh until you see the Docs Home page.
---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
