### PR TITLE
Added data type for should_inline_css

### DIFF
--- a/_docs/_api/endpoints/email_templates.md
+++ b/_docs/_api/endpoints/email_templates.md
@@ -144,7 +144,7 @@ GET https://YOUR_REST_API_URL/templates/email/info
   “preheader”: (optional, string) the email preheader used to generate previews in some clients),
   “body”: (optional, string) the email template body that may include HTML,
   “plaintext_body”: (optional, string) a plaintext version of the email template body,
-  “should_inline_css”
+  “should_inline_css” : (boolean) indicates whether or not Inline CSS is checked in the dashboard template editor,
   “tags”: (string) tag names,
   “created_at”: (string, in ISO 8601),
   “updated_at”: (string, in ISO 8601)

--- a/_docs/_api/endpoints/email_templates.md
+++ b/_docs/_api/endpoints/email_templates.md
@@ -144,7 +144,7 @@ GET https://YOUR_REST_API_URL/templates/email/info
   “preheader”: (optional, string) the email preheader used to generate previews in some clients),
   “body”: (optional, string) the email template body that may include HTML,
   “plaintext_body”: (optional, string) a plaintext version of the email template body,
-  “should_inline_css”: (optional, boolean) whether to inline CSS in the body of the template and defaults to the css inlining value for the App Group,
+  “should_inline_css”: (optional, boolean) whether there is inline CSS in the body of the template - defaults to the css inlining value for the App Group,
   “tags”: (string) tag names,
   “created_at”: (string, in ISO 8601),
   “updated_at”: (string, in ISO 8601)

--- a/_docs/_api/endpoints/email_templates.md
+++ b/_docs/_api/endpoints/email_templates.md
@@ -144,7 +144,7 @@ GET https://YOUR_REST_API_URL/templates/email/info
   “preheader”: (optional, string) the email preheader used to generate previews in some clients),
   “body”: (optional, string) the email template body that may include HTML,
   “plaintext_body”: (optional, string) a plaintext version of the email template body,
-  “should_inline_css” : (boolean) indicates whether or not Inline CSS is checked in the dashboard template editor,
+  “should_inline_css”: (optional, boolean) whether to inline CSS in the body of the template and defaults to the css inlining value for the App Group,
   “tags”: (string) tag names,
   “created_at”: (string, in ISO 8601),
   “updated_at”: (string, in ISO 8601)


### PR DESCRIPTION
Successful response properties for templates/email/info was missing a data type for should_inline_css. Added boolean and brief description. Have tested in Postman to confirm data type.

# Pull Request/Issue Resolution

**Description of Change:**
> I'm adding a data type for should_inline_css so that the response is clear to developers without them needing to test.


**Reason for Change:**
> I'm making this change because it will lead to less confusions for developers.


Closes #**ISSUE_NUMBER_HERE**

### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Feature Release Date:__)
- [x] No

> If yes, please note the date of the feature release.


---
---

## PR Checklist
- [x] Ensure you have completed [our CLA](https://www.braze.com/docs/cla/).
- [x] Tag @EmilyNecciai as a reviewer when the your work is _done and ready to be reviewed for merge_.
- [x] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide).
- [x] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices).
- [x] Tag others as Reviewers as necessary.
- [x] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

## ATTENTION: REVIEWERS OF THIS PR
- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Preview all changes in the linked Heroku environment (click `View deployment` button below, then "Docs". A `502` error just means you should refresh until you see the Docs Home page.
---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
