### PR TITLE
Added link to Pre-populating Custom Data Types

### DIFF
--- a/_docs/_user_guide/data_and_analytics/custom_data/pre-populating_custom_data.md
+++ b/_docs/_user_guide/data_and_analytics/custom_data/pre-populating_custom_data.md
@@ -17,5 +17,6 @@ Then, type in your custom attribute or event. For custom attributes, you'll need
 
 Keep in mind that when your development team integrates these custom events/ attributes later, they will need to name them exactly as you have named them here - including the use of uppercase or lowercase letters - or else Braze will generate a different custom event/ attribute.
 
+[20]: {{ site.baseurl }}/user_guide/data_and_analytics/custom_data/custom_attributes/#custom-attribute-data-types
 [21]: {% image_buster /assets/img_archive/prepopulate_page.png %}
 [22]: {% image_buster /assets/img_archive/prepopulate_add.png %}


### PR DESCRIPTION
# Pull Request/Issue Resolution

**Description of Change:**
> I'm adding a link where one wasn't. 
**Reason for Change:**
> I'm making this change because it was misleading users..

### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Feature Release Date:__)
- [x] No

> If yes, please note the date of the feature release.


---
---

## PR Checklist
- [ ] Ensure you have completed [our CLA](https://www.braze.com/docs/cla/).
- [ ] Tag @EmilyNecciai as a reviewer when the your work is _done and ready to be reviewed for merge_.
- [ ] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide).
- [ ] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices).
- [ ] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

## ATTENTION: REVIEWERS OF THIS PR
- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Preview all changes in the linked Heroku environment (click `View deployment` button below, then "Docs". A `502` error just means you should refresh until you see the Docs Home page.
---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
