### PR TITLE
fix code in td not wrapping

### DIFF
--- a/assets/css/_content.scss
+++ b/assets/css/_content.scss
@@ -472,6 +472,7 @@ table {
 
 table td code.highlighter-rouge {
   background-color: transparent !important;
+  word-break: break-all;
 }
 
 .highlight table {


### PR DESCRIPTION
# Pull Request/Issue Resolution
Code in td wasn't wrapping, causing small width dimension (ie mobile) to render oddly.

**Description of Change:**
> I'm changing..... (could be a link, a new image, a new section, etc.)...
Add word break to code with td.


**Reason for Change:**
> I'm making this change because.....
Small width rendering issue.

Closes #**ISSUE_NUMBER_HERE**

### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Feature Release Date:__)
- [x] No
