### PR TITLE
Changed Push help pages according to example.

### DIFF
--- a/_docs/_help/best_practices/push.md
+++ b/_docs/_help/best_practices/push.md
@@ -1,6 +1,15 @@
 ---
-config_only: true
-page_order: 2
+page_order: 3
 nav_title: Push
-layout: blank_config
+---
+
+# Push
+
+Being able to communicate with your users whether or not they’re “in-app” can be extremely useful, making push notifications a powerful tool. But with power comes responsibility, and used incorrectly, they can be potentially invasive. To escape being pushy, follow the best practices and use cases below to make sure your push messages inspire engagement rather than annoyance.
+
+_Please note that your push messages must fall within the guidelines of the Apple App Store and Google's Play Store policies, specifically regarding using push messages as advertisements, spam, promotions, and more._
+
+_[Learn more here][59]._
+
+[59]: {{ site.baseurl }}/user_guide/message_building_by_channel/push/creating_a_push_message/#creating-a-push-message
 ---

--- a/_docs/_help/best_practices/push/overview.md
+++ b/_docs/_help/best_practices/push/overview.md
@@ -1,13 +1,2 @@
----
-nav_title: Overview
-page_order: 0
----
-# Push
-
-Being able to communicate with your users whether or not they’re “in-app” can be extremely useful, making push notifications a powerful tool. But with power comes responsibility, and used incorrectly, they can be potentially invasive. To escape being pushy, follow the best practices and use cases below to make sure your push messages inspire engagement rather than annoyance.
-
-_Please note that your push messages must fall within the guidelines of the Apple App Store and Google's Play Store policies, specifically regarding using push messages as advertisements, spam, promotions, and more._
-
-_[Learn more here][59]._
-
-[59]: {{ site.baseurl }}/user_guide/message_building_by_channel/push/creating_a_push_message/#creating-a-push-message
+layout: redirect
+redirect_to: /docs/help/best_practices/push


### PR DESCRIPTION
# Pull Request/Issue Resolution

**Description of Change:**
> I'm changing the Push pages in the Help docs according to the provided example.

**Reason for Change:**
> I'm making this change because this is part of the project to change the navigation format globally for the docs.


Closes #**ISSUE_NUMBER_HERE** n/a

### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Feature Release Date:__)
- [ x] No

> If yes, please note the date of the feature release.


---
---

## PR Checklist
- [x ] Ensure you have completed [our CLA](https://www.braze.com/docs/cla/).
- [ x] Tag @EmilyNecciai as a reviewer when your work is _done and ready to be reviewed for merge_.
- [ x] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide).
- [ x] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices).
- [x ] Tag others as Reviewers as necessary.
- [x ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

## ATTENTION: REVIEWERS OF THIS PR
- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Preview all changes in the linked Heroku environment (click `View deployment` button below, then "Docs". A `502` error just means you should refresh until you see the Docs Home page.
---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
