### PR TITLE
Add dispatch_id for Currents Push events in all destinations

### DIFF
--- a/_docs/_partners/braze_currents/data_storage_events/message_engagement_events.md
+++ b/_docs/_partners/braze_currents/data_storage_events/message_engagement_events.md
@@ -35,7 +35,8 @@ Data accumulates when a user engages with a Push Notification, or as a Push Noti
   "canvas_step_id": (string) id of the step for this message if from a Canvas,
   "platform": (string) platform of the device (iOS, Android, web, etc.),
   "device_id": (string) id of the device that we made a delivery attempt to,
-  "send_id": (string) id of the message if specified for the campaign (See Send Identifier under REST API Parameter Definitions)
+  "send_id": (string) id of the message if specified for the campaign (See Send Identifier under REST API Parameter Definitions),
+  "dispatch_id": (string) id of the message dispatch (unique id for each 'transmission' sent from the Braze platform). Users who are sent a schedule message get the same dispatch_id. Action-based or API triggered messages get a unique dispatch_id per user.
 }
 // Push Notification Open: users.messages.pushnotification.Open
 {
@@ -56,7 +57,8 @@ Data accumulates when a user engages with a Push Notification, or as a Push Noti
   "os_version": (string) os version of device used for the action,
   "device_model": (string) hardware model of the device,
   "device_id": (string) id of the device that we made a delivery attempt to,
-  "send_id": (string) id of the message if specified for the campaign (See Send Identifier under REST API Parameter Definitions)
+  "send_id": (string) id of the message if specified for the campaign (See Send Identifier under REST API Parameter Definitions),
+  "dispatch_id": (string) id of the message dispatch (unique id for each 'transmission' sent from the Braze platform). Users who are sent a schedule message get the same dispatch_id. Action-based or API triggered messages get a unique dispatch_id per user.
 }
 // Push Notification iOS Foreground: users.messages.pushnotification.IosForeground
 {
@@ -75,7 +77,8 @@ Data accumulates when a user engages with a Push Notification, or as a Push Noti
   "canvas_step_id": (string) id of the step for this message if from a Canvas,
   "platform": (string) platform of the device (iOS, Android, web, etc.),
   "device_id": (string) id of the device that we made a delivery attempt to,
-  "send_id": (string) id of the message if specified for the campaign (See Send Identifier under REST API Parameter Definitions)
+  "send_id": (string) id of the message if specified for the campaign (See Send Identifier under REST API Parameter Definitions),
+  "dispatch_id": (string) id of the message dispatch (unique id for each 'transmission' sent from the Braze platform). Users who are sent a schedule message get the same dispatch_id. Action-based or API triggered messages get a unique dispatch_id per user.
 }
 // Push Notification Bounce: users.messages.pushnotification.Bounce
 {
@@ -94,7 +97,8 @@ Data accumulates when a user engages with a Push Notification, or as a Push Noti
   "canvas_step_id": (string) id of the step for this message if from a Canvas,
   "platform": (string) platform of the device (iOS, Android, web, etc.),
   "device_id": (string) id of the device that we made a delivery attempt to,
-  "send_id": (string) id of the message if specified for the campaign (See Send Identifier under REST API Parameter Definitions)
+  "send_id": (string) id of the message if specified for the campaign (See Send Identifier under REST API Parameter Definitions),
+  "dispatch_id": (string) id of the message dispatch (unique id for each 'transmission' sent from the Braze platform). Users who are sent a schedule message get the same dispatch_id. Action-based or API triggered messages get a unique dispatch_id per user.
 }
 ```
 {% enddetails %}

--- a/_docs/_partners/technology_partners/insights/behavioral_analytics/amplitude_for_currents.md
+++ b/_docs/_partners/technology_partners/insights/behavioral_analytics/amplitude_for_currents.md
@@ -153,7 +153,8 @@ Devices should not report more than 60 events/second under normal circumstances,
   "canvas_step_id": (string) id of the step for this message if from a Canvas,
   "send_id": (string) id of the message if specified for the campaign (See Send Identifier under REST API Parameter Definitions),
   "app_id": (string) id for the app on which the user action occurred,
-  "platform": (string) platform of the device (iOS, Android, web, etc.)
+  "platform": (string) platform of the device (iOS, Android, web, etc.),
+  "dispatch_id": (string) id of the message dispatch (unique id for each 'transmission' sent from the Braze platform). Users who are sent a schedule message get the same dispatch_id. Action-based or API triggered messages get a unique dispatch_id per user.
 }
 // Push Notification Open
 {
@@ -168,7 +169,8 @@ Devices should not report more than 60 events/second under normal circumstances,
   "app_id": (string) id for the app on which the user action occurred,
   "platform": (string) platform of the device (iOS, Android, web, etc.),
   "os_version": (string) os version of device used for the action,
-  "device_model": (string) hardware model of the device
+  "device_model": (string) hardware model of the device,
+  "dispatch_id": (string) id of the message dispatch (unique id for each 'transmission' sent from the Braze platform). Users who are sent a schedule message get the same dispatch_id. Action-based or API triggered messages get a unique dispatch_id per user.
 }
 // Push Notification iOS Foreground Open
 {
@@ -181,7 +183,8 @@ Devices should not report more than 60 events/second under normal circumstances,
   "canvas_step_id": (string) id of the step for this message if from a Canvas,
   "send_id": (string) id of the message if specified for the campaign (See Send Identifier under REST API Parameter Definitions),
   "app_id": (string) id for the app on which the user action occurred,
-  "platform": (string) platform of the device (iOS, Android, web, etc.)
+  "platform": (string) platform of the device (iOS, Android, web, etc.),
+  "dispatch_id": (string) id of the message dispatch (unique id for each 'transmission' sent from the Braze platform). Users who are sent a schedule message get the same dispatch_id. Action-based or API triggered messages get a unique dispatch_id per user.
 }
 // Push Notification Bounce
 {
@@ -194,7 +197,8 @@ Devices should not report more than 60 events/second under normal circumstances,
   "canvas_step_id": (string) id of the step for this message if from a Canvas,
   "send_id": (string) id of the message if specified for the campaign (See Send Identifier under REST API Parameter Definitions),
   "app_id": (string) id for the app on which the bounce occurred,
-  "platform": (string) platform of the device (iOS, Android, web, etc.)
+  "platform": (string) platform of the device (iOS, Android, web, etc.),
+  "dispatch_id": (string) id of the message dispatch (unique id for each 'transmission' sent from the Braze platform). Users who are sent a schedule message get the same dispatch_id. Action-based or API triggered messages get a unique dispatch_id per user.
 }
 ```
 

--- a/_docs/_partners/technology_partners/insights/behavioral_analytics/mixpanel_for_currents.md
+++ b/_docs/_partners/technology_partners/insights/behavioral_analytics/mixpanel_for_currents.md
@@ -136,7 +136,8 @@ You can manage the Mixpanel Cohort Import process from the Technology Partners p
   "canvas_step_id": (string) id of the step for this message if from a Canvas,
   "send_id": (string) id of the message if specified for the campaign (See Send Identifier under REST API Parameter Definitions),
   "app_id": (string) id for the app on which the user action occurred,
-  "platform": (string) platform of the device (iOS, Android, web, etc.)
+  "platform": (string) platform of the device (iOS, Android, web, etc.),
+  "dispatch_id": (string) id of the message dispatch (unique id for each 'transmission' sent from the Braze platform). Users who are sent a schedule message get the same dispatch_id. Action-based or API triggered messages get a unique dispatch_id per user.
 }
 // Push Notification Open
 {
@@ -151,7 +152,8 @@ You can manage the Mixpanel Cohort Import process from the Technology Partners p
   "app_id": (string) id for the app on which the user action occurred,
   "platform": (string) platform of the device (iOS, Android, web, etc.),
   "os_version": (string) os version of device used for the action,
-  "device_model": (string) hardware model of the device
+  "device_model": (string) hardware model of the device,
+  "dispatch_id": (string) id of the message dispatch (unique id for each 'transmission' sent from the Braze platform). Users who are sent a schedule message get the same dispatch_id. Action-based or API triggered messages get a unique dispatch_id per user.
 }
 // Push Notification iOS Foreground Open
 {
@@ -164,7 +166,8 @@ You can manage the Mixpanel Cohort Import process from the Technology Partners p
   "canvas_step_id": (string) id of the step for this message if from a Canvas,
   "send_id": (string) id of the message if specified for the campaign (See Send Identifier under REST API Parameter Definitions),
   "app_id": (string) id for the app on which the user action occurred,
-  "platform": (string) platform of the device (iOS, Android, web, etc.)
+  "platform": (string) platform of the device (iOS, Android, web, etc.),
+  "dispatch_id": (string) id of the message dispatch (unique id for each 'transmission' sent from the Braze platform). Users who are sent a schedule message get the same dispatch_id. Action-based or API triggered messages get a unique dispatch_id per user.
 }
 // Push Notification Bounce
 {
@@ -177,7 +180,8 @@ You can manage the Mixpanel Cohort Import process from the Technology Partners p
   "canvas_step_id": (string) id of the step for this message if from a Canvas,
   "send_id": (string) id of the message if specified for the campaign (See Send Identifier under REST API Parameter Definitions),
   "app_id": (string) id for the app on which the bounce occurred,
-  "platform": (string) platform of the device (iOS, Android, web, etc.)
+  "platform": (string) platform of the device (iOS, Android, web, etc.),
+  "dispatch_id": (string) id of the message dispatch (unique id for each 'transmission' sent from the Braze platform). Users who are sent a schedule message get the same dispatch_id. Action-based or API triggered messages get a unique dispatch_id per user.
 }
 ```
 


### PR DESCRIPTION
Coming in late, but this adds documentation for `dispatch_id` as a field for Currents Push events.

This can be merged immediately.

# Pull Request/Issue Resolution

**Description of Change:**
> I'm changing..... (could be a link, a new image, a new section, etc.)...


**Reason for Change:**
> I'm making this change because.....


Closes #**ISSUE_NUMBER_HERE**

### Is this change associated with a Braze feature/product release?
- [x] Yes 
- [ ] No

> If yes, please note the date of the feature release.


---
---

## PR Checklist
- [ ] Ensure you have completed [our CLA](https://www.braze.com/docs/cla/).
- [ ] Tag @EmilyNecciai as a reviewer when the your work is _done and ready to be reviewed for merge_.
- [ ] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide).
- [ ] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices).
- [ ] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

## ATTENTION: REVIEWERS OF THIS PR
- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Preview all changes in the linked Heroku environment (click `View deployment` button below, then "Docs". A `502` error just means you should refresh until you see the Docs Home page.
---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
