### PR TITLE
Clarify that `appboy://action` schema is only supported in mobile app SDKs

### DIFF
--- a/_docs/_user_guide/message_building_by_channel/in-app_messages/customize.md
+++ b/_docs/_user_guide/message_building_by_channel/in-app_messages/customize.md
@@ -25,8 +25,7 @@ If you choose to apply your own template, click __Apply Template__ and choose fr
 
 While Braze’s out-of-the box in-app messages can be customized in a variety of ways, you can gain even greater control over the look and feel of your campaigns using messages designed and built using HTML, CSS, and Javascript. With some simple composition, you can unlock custom functionality and branding to match any of your needs. HTML in-app messages allow for greater control over the look and feel of a message, and anything supported by HTML5 is also supported by Braze.
 
-#### JavaScript Bridge (appboyBridge)
-
+#### <a id="iam-customize-javascript-bridge">JavaScript Bridge (appboyBridge)</a>
 HTML in-app messages support a Javascript "bridge" interface to the Braze Web SDK, allowing you to trigger custom Braze actions when users click on elements with links or otherwise engage with your content. The following javascript methods are supported in Braze's HTML in-app messages:
 
 {% include archive/appboyBridge.md platform="web" %}
@@ -37,9 +36,9 @@ Additionally, for analytics tracking, any `<a>` or `<button>` elements in your H
   To enable HTML in-app messages, your SDK integration must supply the `enableHtmlInAppMessages` initialization option to Braze: for example `appboy.initialize('YOUR-API_KEY', {enableHtmlInAppMessages: true})`. This is for security reasons - HTML in-app messages can execute javascript so we require a site maintainer to enable them.
 {% endalert %}
 
-#### Link-Based Actions
+#### Link-Based Actions (Mobile Apps)
 
-HTML in-app messages can trigger custom Braze actions when users click on elements with links. The supported link schemes are:
+HTML in-app messages on mobile apps can trigger custom Braze actions when users click on elements with links. The supported link schemes are:
 
 Supported Scheme | Corresponding Action | Supported Query Strings
 --- | --- |---
@@ -47,6 +46,10 @@ Normal Web URL or Deep Linking | For web URLs, Braze will open the new content o
 `appboy://close` | Braze will dismiss the HTML in-app message. | None
 `appboy://feed` | Braze will dismiss the HTML in-app message and display a modal News Feed. | `abButtonId`
 `appboy://customEvent` | Braze will log a custom event and will NOT dismiss the HTML in-app message. | `name`<br>All additional queries will be set as properties of the custom event.
+
+{% alert tip %}
+Link-based actions are not supported by the Web SDK. For cross-platform compatibility, please refer to the [Javascript Bridge](#iam-customize-javascript-bridge) methods.
+{% endalert %}
 
 #### Supported Query Strings
 

--- a/_docs/_user_guide/message_building_by_channel/in-app_messages/customize.md
+++ b/_docs/_user_guide/message_building_by_channel/in-app_messages/customize.md
@@ -49,7 +49,7 @@ Normal Web URL or Deep Linking | For web URLs, Braze will open the new content o
 `appboy://customEvent` | Braze will log a custom event and will NOT dismiss the HTML in-app message. | `name`<br>All additional queries will be set as properties of the custom event.
 
 {% alert tip %}
-Link-based actions are not supported by the Web SDK. For cross-platform compatibility, please refer to the [Javascript Bridge](#iam-customize-javascript-bridge) methods.
+Link-based actions are not supported by the Web SDK. For cross-platform compatibility, please refer to the [Javascript Bridge](#javascript-bridge) methods.
 {% endalert %}
 
 #### Supported Query Strings

--- a/_docs/_user_guide/message_building_by_channel/in-app_messages/customize.md
+++ b/_docs/_user_guide/message_building_by_channel/in-app_messages/customize.md
@@ -25,7 +25,8 @@ If you choose to apply your own template, click __Apply Template__ and choose fr
 
 While Braze’s out-of-the box in-app messages can be customized in a variety of ways, you can gain even greater control over the look and feel of your campaigns using messages designed and built using HTML, CSS, and Javascript. With some simple composition, you can unlock custom functionality and branding to match any of your needs. HTML in-app messages allow for greater control over the look and feel of a message, and anything supported by HTML5 is also supported by Braze.
 
-#### <a id="iam-customize-javascript-bridge">JavaScript Bridge (appboyBridge)</a>
+#### JavaScript Bridge (appboyBridge) {#javascript-bridge}
+
 HTML in-app messages support a Javascript "bridge" interface to the Braze Web SDK, allowing you to trigger custom Braze actions when users click on elements with links or otherwise engage with your content. The following javascript methods are supported in Braze's HTML in-app messages:
 
 {% include archive/appboyBridge.md platform="web" %}


### PR DESCRIPTION
`appboy://action` schema is not supported by the web SDK. This updates the docs to clarify

https://www.braze.com/docs/user_guide/message_building_by_channel/in-app_messages/customize/#customization