### PR TITLE
Set a Card as dismissed Method for Android- 235

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/android/content_cards/customization.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/content_cards/customization.md
@@ -4,7 +4,7 @@ page_order: 1
 search_rank: 5
 platform: Android
 ---
-# Customization 
+# Customization
 
 ## Default Styling {#default-styling-for-android}
 
@@ -77,7 +77,7 @@ To set a custom pinned icon, override the `Appboy.ContentCards.PinnedIcon` style
 
 ### Customizing Displayed Card Order {#customizing-displayed-card-order-for-android}
 
-The `AppboyContentCardsFragment` relies on a [`IContentCardsUpdateHandler`][44] to handle any sorting or modifications of Content Cards before they are displayed in the feed. A custom update handler can be set via [`setContentCardUpdateHandler`][45] on your [`AppboyContentCardsFragment`][47]. 
+The `AppboyContentCardsFragment` relies on a [`IContentCardsUpdateHandler`][44] to handle any sorting or modifications of Content Cards before they are displayed in the feed. A custom update handler can be set via [`setContentCardUpdateHandler`][45] on your [`AppboyContentCardsFragment`][47].
 
 Filtering out Content Cards before they reach the user's feed is a common use-case and could be achieved by reading the key-value pairs set on the dashboard via [`Card.getExtras()`][36] and performing any logic you'd like in the update handler.
 
@@ -481,6 +481,16 @@ When using custom views, you will need to log analytics manually as well, since 
 To log a display of the Content Cards, call [`Appboy.logContentCardsDisplayed()`][41].
 
 To log an impression or click on a Card, call [`Card.logClick()`][7] or [`Card.logImpression()`][8] respectively.
+
+#### Manually Dismissing a Content Card
+
+You can manually log or set a Content Card as "dismissed" to Braze [for a particular card with `setIsDismissed`](https://appboy.github.io/appboy-android-sdk/javadocs/com/appboy/models/cards/Card.html#setIsDismissed-boolean-).
+
+```java
+public void setIsDismissed(boolean isDismissed)
+```
+
+If a card is already marked as dismissed, it cannot be marked as dismissed again.
 
 ## Key-Value Pairs
 `Card` objects may optionally carry key-value pairs as `extras`. These can be used to send data down along with a `Card` for further handling by the application.

--- a/_docs/_developer_guide/platform_integration_guides/android/content_cards/customization.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/content_cards/customization.md
@@ -486,10 +486,6 @@ To log an impression or click on a Card, call [`Card.logClick()`][7] or [`Card.l
 
 You can manually log or set a Content Card as "dismissed" to Braze [for a particular card with `setIsDismissed`](https://appboy.github.io/appboy-android-sdk/javadocs/com/appboy/models/cards/Card.html#setIsDismissed-boolean-).
 
-```java
-public void setIsDismissed(boolean isDismissed)
-```
-
 If a card is already marked as dismissed, it cannot be marked as dismissed again.
 
 ## Key-Value Pairs


### PR DESCRIPTION
# Pull Request/Issue Resolution

**Description of Change:**
> `"logContentCardDismissed` - Manually log a dismissal to Braze for a particular card is present in the iOS documentation. However, this was missing from the Android one in the link posted below. https://appboy.github.io/appboy-android-sdk/javadocs/com/appboy/models/cards/Card.html#setIsDismissed-boolean-

Closes internal req.

### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Feature Release Date:__)
- [ ] No

> If yes, please note the date of the feature release.


---
---

## PR Checklist
- [ ] Ensure you have completed [our CLA](https://www.braze.com/docs/cla/).
- [ ] Tag @EmilyNecciai as a reviewer when the your work is _done and ready to be reviewed for merge_.
- [ ] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide).
- [ ] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices).
- [ ] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

## ATTENTION: REVIEWERS OF THIS PR
- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Preview all changes in the linked Heroku environment (click `View deployment` button below, then "Docs". A `502` error just means you should refresh until you see the Docs Home page.
---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
