### PR TITLE
abort_message() always logs default error

### DIFF
--- a/_docs/_user_guide/personalization_and_dynamic_content/liquid/aborting_messages.md
+++ b/_docs/_user_guide/personalization_and_dynamic_content/liquid/aborting_messages.md
@@ -28,7 +28,13 @@ Send this message in English!
 {% endif %}
 ```
 
-You can have the abort_message log something to your Developer Console log by including a string inside the parentheses:
+By default Braze will log a generic error message to your Developer Console log:
+
+```text
+{% abort_message %} called
+```
+
+You can also have the abort_message log something to your Developer Console log by including a string inside the parentheses:
 
 ```liquid
 {% abort_message('language was nil') %}


### PR DESCRIPTION
# Pull Request/Issue Resolution

**Description of Change:**
> I'm changing https://www.braze.com/docs/user_guide/personalization_and_dynamic_content/liquid/aborting_messages/


**Reason for Change:**
> I'm making this change because this doc was a bit misleading that the readers thought no error message would be logged when `abort_message()` is called without params. In fact, it will always log some default messages, so this change is to make it clearer.


Closes #**ISSUE_NUMBER_HERE**

### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Feature Release Date:__)
- [x] No

> If yes, please note the date of the feature release.


---
---

## PR Checklist
- [x] Ensure you have completed [our CLA](https://www.braze.com/docs/cla/).
- [ ] Tag @EmilyNecciai as a reviewer when the your work is _done and ready to be reviewed for merge_.
- [x] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide).
- [x] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices).
- [x] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

## ATTENTION: REVIEWERS OF THIS PR
- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Preview all changes in the linked Heroku environment (click `View deployment` button below, then "Docs". A `502` error just means you should refresh until you see the Docs Home page.
---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
