### PR TITLE
Remove example using deprecated callback

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/web/push_notifications/integration.md
+++ b/_docs/_developer_guide/platform_integration_guides/web/push_notifications/integration.md
@@ -116,9 +116,8 @@ appboy.subscribeToNewInAppMessages(function(inAppMessages) {
 When you wish to display the soft push prompt to the user, call `appboy.logCustomEvent("prime-for-push")` - for instance, to prompt the user on every page load just after the Braze session begins, your code would look like:
 
 ```
-appboy.openSession(function() {
-  appboy.logCustomEvent("prime-for-push");
-});
+appboy.openSession();
+appboy.logCustomEvent("prime-for-push");
 ```
 
 [1]: http://www.w3.org/TR/push-api/


### PR DESCRIPTION
# Pull Request/Issue Resolution

**Description of Change:**
This callback usage is deprecated in the Web SDK because it is not required as of 2.3.1


Closes #**ISSUE_NUMBER_HERE**

### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Feature Release Date:__)
- [ ] No

> If yes, please note the date of the feature release.


---
---

## PR Checklist
- [ ] Ensure you have completed [our CLA](https://www.braze.com/docs/cla/).
- [ ] Tag @EmilyNecciai as a reviewer when the your work is _done and ready to be reviewed for merge_.
- [ ] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide).
- [ ] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices).
- [ ] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

## ATTENTION: REVIEWERS OF THIS PR
- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Preview all changes in the linked Heroku environment (click `View deployment` button below, then "Docs". A `502` error just means you should refresh until you see the Docs Home page.
---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
