### PR TITLE
[do not merge until 10/22] ad-ids-update

### DIFF
--- a/_docs/_api/endpoints/export.md
+++ b/_docs/_api/endpoints/export.md
@@ -222,6 +222,9 @@ User export object (we will include the least data possible - if a field is miss
             "carrier" : (string),
             "idfv" : (string) only included for iOS devices,
             "idfa" : (string) only included for iOS devices when IDFA collection is enabled,
+            "google_ad_id" : (string) only included for Android devices when Google Play Advertising Identifier collection is enabled,
+            "roku_ad_id" : (string) only included for Roku devices,
+            "windows_ad_id" : (string) only included for Windows devices,
             "ad_tracking_enabled" : (bool)
         },
         ...

--- a/_docs/_developer_guide/platform_integration_guides/android/initial_sdk_setup/optional_gaid_collection.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/initial_sdk_setup/optional_gaid_collection.md
@@ -3,7 +3,6 @@ nav_title: Google Advertising ID
 platform: Android
 page_order: 9
 search_rank: 5
-hidden: true
 ---
 
 # Optional Google Advertising ID

--- a/_docs/_developer_guide/platform_integration_guides/android/initial_sdk_setup/optional_gaid_collection.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/initial_sdk_setup/optional_gaid_collection.md
@@ -1,0 +1,57 @@
+---
+nav_title: Google Advertising ID
+platform: Android
+page_order: 9
+search_rank: 5
+hidden: true
+---
+
+# Optional Google Advertising ID
+
+The Google Advertising ID is a user-specific, unique, resettable ID for advertising, provided by Google Play services. It gives users better controls and provides developers with a simple, standard system to continue to monetize your apps. It is an anonymous identifier for advertising purposes and enables users to reset their identifier or opt out of interest-based ads within Google Play apps. See [here][2] for more information.
+
+## Passing the Google Advertising ID to Braze
+
+The Google Advertising ID is not automatically collected by the Braze SDK and must be set manually via the [`Appboy.setGoogleAdvertisingId()`][1] method.
+
+{% alert important %}
+Google requires the Advertising ID to be collected on a non-UI thread.
+{% endalert %}
+
+{% tabs %}
+{% tab JAVA %}
+
+```java
+new Thread(new Runnable() {
+  @Override
+  public void run() {
+    try {
+      AdvertisingIdClient.Info idInfo = AdvertisingIdClient.getAdvertisingIdInfo(getApplicationContext());
+      Appboy.getInstance(getApplicationContext()).setGoogleAdvertisingId(idInfo.getId(), idInfo.isLimitAdTrackingEnabled());
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+}).start();
+```
+
+{% endtab %}
+{% tab KOTLIN %}
+
+```kotlin
+Thread(Runnable {
+  try {
+    val idInfo = AdvertisingIdClient.getAdvertisingIdInfo(getApplicationContext())
+    Appboy.getInstance(getApplicationContext()).setGoogleAdvertisingId(idInfo.id, idInfo.isLimitAdTrackingEnabled)
+  } catch (e: Exception) {
+    e.printStackTrace()
+  }
+}).start()
+```
+
+{% endtab %}
+{% endtabs %}
+
+
+[1]: https://appboy.github.io/appboy-android-sdk/javadocs/com/appboy/Appboy.html#setGoogleAdvertisingId-java.lang.String-boolean-
+[2]: http://www.androiddocs.com/google/play-services/id.html

--- a/_docs/_user_guide/personalization_and_dynamic_content/liquid/supported_personalization_tags.md
+++ b/_docs/_user_guide/personalization_and_dynamic_content/liquid/supported_personalization_tags.md
@@ -12,8 +12,8 @@ As a convenience, a summary of supported personalization tags are listed below. 
 | Personalization Tag Type | Tags |
 | -------------  | ---- |
 | Default Attributes | `{{${city}}}` <br> `{{${country}}}` <br> `{{${date_of_birth}}}` <br> `{{${email_address}}}` <br> `{{${first_name}}}` <br> `{{${gender}}}` <br> `{{${language}}}` <br> `{{${last_name}}}` <br> `{{${last_used_app_date}}}` <br> `{{${most_recent_app_version}}}` <br> `{{${most_recent_locale}}}` <br> `{{${most_recent_location}}}` <br> `{{${phone_number}}}` <br> `{{${time_zone}}}` <br> `{{${twitter_handle}}}` <br> `{{${user_id}}}` <br> `{{${braze_id}}}` |
-| Device Attributes | `{{most_recently_used_device.${carrier}}}` <br> `{{most_recently_used_device.${id}}}` <br> `{{most_recently_used_device.${idfa}}}` <br> `{{most_recently_used_device.${model}}}` <br> `{{most_recently_used_device.${os}}}` <br> `{{most_recently_used_device.${platform}}}` |
-| Email List Attributes <br> (Learn more [here][43]). | `{{${set_user_to_unsubscribed_url}}}` <br> `{{${set_user_to_subscribed_url}}}` <br> `{{${set_user_to_opted_in_url}}}` |
+| Device Attributes | `{{most_recently_used_device.${carrier}}}` <br> `{{most_recently_used_device.${id}}}` <br> `{{most_recently_used_device.${idfa}}}` <br> `{{most_recently_used_device.${model}}}` <br> `{{most_recently_used_device.${os}}}` <br> `{{most_recently_used_device.${platform}}}` <br> `{{most_recently_used_device.${google_ad_id}}}` <br> `{{most_recently_used_device.${roku_ad_id}}}` <br> `{{most_recently_used_device.${windows_ad_id}}}`|
+| Email List Attributes <br> (Learn more [here][43]). | `{{${set_user_to_unsubscribed_url}}}` <br> `{{${set_user_to_subscribed_url}}}` <br> `{{${set_user_to_opted_in_url}}}`|
 | Campaign Attributes | `{{campaign.${api_id}}}` <br> `{{campaign.${dispatch_id}}}` <br> `{{campaign.${name}}}` |
 | Canvas Attributes | `{{canvas.${name}}}` <br> `{{canvas.${api_id}}}` <br> `{{canvas.${variant_name}}}` <br> `{{canvas.${variant_api_id}}}` |
 | Card Attributes | `{{card.${api_id}}}` <br> `{{card.${name}}}` |
@@ -46,6 +46,9 @@ You can template in the following attributes for the user's most recent device a
 |`{{most_recently_used_device.${id}}}` | This is Braze's device identifier. On iOS, this is the Apple Identifier for Vendor (IDFV). For Android and other platforms, it is Braze's device identifier, a randomly generated GUID. |
 | `{{most_recently_used_device.${carrier}}}` | The most recently used device's telephone service carrier, if available. Examples include "Verizon" and "Orange". |
 | `{{most_recently_used_device.${idfa}}}` | For iOS devices, this value will be the Identifier for Advertising (IDFA) if your application is configured with Braze's [optional IDFA collection][40]. For non-iOS devices, this value will be null. |
+| `{{most_recently_used_device.${google_ad_id}}}` | For Android devices, this value will be the Google Play Advertising Identifier if your application is configured with Braze's [optional Google Play Advertising ID collection]. For non-Android devices, this value will be null. |
+| `{{most_recently_used_device.${roku_ad_id}}}` | For Roku devices, this value will be the Roku Advertising Identifier that is collected when your application is configured with Braze. For non-Roku devices, this value will be null. |
+| `{{most_recently_used_device.${windows_ad_id}}}` | For Windows devices, this value will be the Windows Advertising Identifier that is collected when your application is configured with Braze. For non-Windows devices, this value will be null. |
 | `{{most_recently_used_device.${model}}}` | The device's model name, if available. Examples include "iPhone 6S" and "Nexus 6P" and "Firefox". |
 | `{{most_recently_used_device.${os}}}` | The device's operating system, if available. Examples include "iOS 9.2.1" and "Android (Lollipop)" and "Windows". |
 | `{{most_recently_used_device.${platform}}}` | The device's platform, if available. If set, the value will be one of `ios`, `android`, `windows`, `windows8`, `kindle`, `android_china`, `web`, or `tvos`. |
@@ -57,10 +60,13 @@ Because there are such a wide range of device carriers, model names, and operati
 For push notification and in-app message channels, you can template in the following attributes for the device to which a message is being sent. That is, a push notification or in-app message can include device attributes of the device on which the message is being read.
 
 |Tag | Description |
-|---|---|
+|------------------|---|
 | `{{targeted_device.${id}}}` | This is Braze's device identifier. On iOS, this is the Apple Identifier for Vendor (IDFV). For Android and other platforms, it is Braze's device identifier, a randomly generated GUID. |
 | `{{targeted_device.${carrier}}}` | The most recently used device's telephone service carrier, if available. Examples include "Verizon" and "Orange". |
 | `{{targeted_device.${idfa}}}` | For iOS devices, this value will be the Identifier for Advertising (IDFA) if your application is configured with Braze's [optional IDFA collection][40]. For non-iOS devices, this value will be null. |
+| `{{targeted_device.${google_ad_id}}}` | For Android devices, this value will be the Google Play Advertising Identifier if your application is configured with Braze's [optional Google Play Advertising ID collection]. For non-Android devices, this value will be null. |
+| `{{targeted_device.${roku_ad_id}}}` | For Roku devices, this value will be the Roku Advertising Identifier that is collected when your application is configured with Braze. For non-Roku devices, this value will be null. |
+| `{{targeted_device.${windows_ad_id}}}` | For Windows devices, this value will be the Windows Advertising Identifier that is collected when your application is configured with Braze. For non-Windows devices, this value will be null. |
 | `{{targeted_device.${model}}}` | The device's model name, if available. Examples include "iPhone 6S" and "Nexus 6P" and "Firefox". |
 | `{{targeted_device.${os}}}` | The device's operating system, if available. Examples include "iOS 9.2.1" and "Android (Lollipop)" and "Windows". |
 | `{{targeted_device.${platform}}}` | The device's platform, if available. If set, the value will be one of `ios`, `android`, `windows`, `windows8`, `kindle`, `android_china`, `web`, or `tvos`. |


### PR DESCRIPTION
# Pull Request/Issue Resolution

**Description of Change:**
- added google, windows, and roku ad ids to liquid doc
- added google, windows, and roku fields within device object in export api doc 

**Reason for Change:**

We are adding google play, roku, and windows ad ids into: 
- user profile 
- liquid
- filters 
- export api 
- currents 

as part of our GAID epic > to expose the google play ad id (windows and roku were just bonuses). 

this will assist with making it easier partner integrations within ad tech. 

Closes #**ISSUE_NUMBER_HERE**

### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Feature Release Date:__)
- [ ] No

> If yes, please note the date of the feature release.


---
---

## PR Checklist
- [ ] Ensure you have completed [our CLA](https://www.braze.com/docs/cla/).
- [ ] Tag @EmilyNecciai as a reviewer when the your work is _done and ready to be reviewed for merge_.
- [ ] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide).
- [ ] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices).
- [ ] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

## ATTENTION: REVIEWERS OF THIS PR
- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Preview all changes in the linked Heroku environment (click `View deployment` button below, then "Docs". A `502` error just means you should refresh until you see the Docs Home page.
---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
