### PR TITLE
Include message structure for exported content cards

### DIFF
--- a/_docs/_api/endpoints/export.md
+++ b/_docs/_api/endpoints/export.md
@@ -825,7 +825,7 @@ The `messages` hash will contain information about each message. Example message
 {
     "channel": "content_cards",
     "name": (string) name of variant,
-    "extras": (hash) any key-value pairs provided, only present if at least one custom key-value pair has been set
+    "extras": (hash) any key-value pairs provided; only present if at least one key-value pair has been set
 }
 ```
 

--- a/_docs/_api/endpoints/export.md
+++ b/_docs/_api/endpoints/export.md
@@ -819,6 +819,16 @@ The `messages` hash will contain information about each message. Example message
 }
 ```
 
+**Content Card Channel**
+
+```json
+{
+    "channel": "content_cards",
+    "name": (string) name of variant,
+    "extras": (hash) any key-value pairs provided, only present if at least one custom key-value pair has been set
+}
+```
+
 **Webhook Channel**
 
 ```json


### PR DESCRIPTION
# Pull Request

**Description of Change:**
> I'm extending the Campaign Details Export Endpoint to include the json structure for content card messages.


**Reason for Change:**
> I'm making this change because I was looking this up for myself and had to execute the endpoint to find out the json structure and I think it would be easier to just read it in the docs.

### Is this change associated with a Braze feature/product release?
- [ ] Yes
- [X] No

> If yes, please note the date of the feature release.


---
---

## PR Checklist
- [X] Ensure you have completed [our CLA](https://www.braze.com/docs/cla/).
- [ ] Tag @EmilyNecciai as a reviewer when the your work is _done and ready to be reviewed for merge_.
- [X] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide).
- [X] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices).
- [ ] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

## ATTENTION: REVIEWERS OF THIS PR
- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Preview all changes in the linked Heroku environment (click `View deployment` button below, then "Docs". A `502` error just means you should refresh until you see the Docs Home page.
---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
