### PR TITLE
Update initial_sdk_setup for Web SDK

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/web/initial_sdk_setup.md
+++ b/_docs/_developer_guide/platform_integration_guides/web/initial_sdk_setup.md
@@ -16,15 +16,11 @@ Substitute the API key found within the "App Settings" page (labeled "API Key" i
 
 ![API Key Location][14]
 
-If you have been provided a custom SDK endpoint, please include this in addition to your API key:
+Your Braze representative should have already advised you of the [correct endpoint]({{ site.baseurl }}/user_guide/administrative/access_braze/sdk_endpoints). Reference the endpoint within your initialization snippet, for example:
 
-US Cluster:
+*For US-03*: `appboy.initialize(‘YOUR-API-KEY-HERE’,{baseUrl:’https://sdk.iad-03.braze.com/api/v3’})` 
 
-`appboy.initialize('YOUR-API-KEY-HERE', {baseUrl: 'https://customer.iad-03.braze.com/api/v3'})`
-
-EU Cluster:
-
-`appboy.initialize('YOUR-API-KEY-HERE', {baseUrl: 'https://customer.fra-01.braze.eu/api/v3'})`
+*For EU-01*: `appboy.initialize(‘YOUR-API-KEY-HERE’,{baseUrl:’https://fra-01.iad-01.braze.eu/api/v3’})`
 
 ## Enable Error Logging {#error-logging}
 
@@ -44,7 +40,7 @@ To initialize Braze’s SDK create a ‘Custom HTML’ tag within your Google Ta
 
 Subsequent tags which fire after page load can then reference this. For example `<script type="text/javascript">window.appboy.logCustomEvent("test event")</script>`.
 
-Please also ensure to replace the API key and custom SDK endpoint in the code with your API key and, if applicable, custom endpoint.
+Please also ensure to replace the API key and custom SDK endpoint in the code with your API key.
 
 Braze suggests the tag has the trigger configuration of **Page View > DOM Ready**. Other Page View triggers can fire the tag, provided that no other Braze related tags are fired to prior to this.
 


### PR DESCRIPTION

# Pull Request/Issue Resolution

**Description of Change:**
Removed mention of Custom Endpoints as we no longer provide them to customers and they are not required even for customers who historically were provided them. Added in info on which endpoint to use.


**Reason for Change:**
we don't use custom endpoints with customers anymore

Closes #**ISSUE_NUMBER_HERE**

### Is this change associated with a Braze feature/product release?
No

> If yes, please note the date of the feature release.


---
---

## PR Checklist
- [ ] Ensure you have completed [our CLA](https://www.braze.com/docs/cla/).
- [ ] Tag @EmilyNecciai as a reviewer when the your work is _done and ready to be reviewed for merge_.
- [ ] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide).
- [ ] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices).
- [ ] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

## ATTENTION: REVIEWERS OF THIS PR
- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Preview all changes in the linked Heroku environment (click `View deployment` button below, then "Docs". A `502` error just means you should refresh until you see the Docs Home page.
---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
