### PR TITLE
Add kotlin syntax for getExtras

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/android/in-app_messaging/customization.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/in-app_messaging/customization.md
@@ -15,9 +15,23 @@ In-app message objects may carry key-value pairs as `extras`. They are specified
 
 Call the following when you get an in-app message object to retrieve its extras:
 
-```
+{% tabs %}
+{% tab JAVA %}
+
+
+```java
 Map<String, String> getExtras()
 ```
+
+{% endtab %}
+{% tab KOTLIN %}
+
+```kotlin
+extras: Map<String, String>
+```
+
+{% endtab %}
+{% endtabs %}
 
 See the [Javadoc][44] for more information.
 

--- a/_docs/_developer_guide/platform_integration_guides/android/in-app_messaging/customization.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/in-app_messaging/customization.md
@@ -18,7 +18,6 @@ Call the following when you get an in-app message object to retrieve its extras:
 {% tabs %}
 {% tab JAVA %}
 
-
 ```java
 Map<String, String> getExtras()
 ```

--- a/_docs/_developer_guide/platform_integration_guides/android/news_feed/key-value_pairs.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/news_feed/key-value_pairs.md
@@ -10,9 +10,22 @@ platform: Android
 
 Call the following on a `Card` object to retrieve its extras:
 
+{% tabs %}
+{% tab JAVA %}
+
 ```java
 Map<String, String> getExtras()
 ```
+
+{% endtab %}
+{% tab KOTLIN %}
+
+```kotlin
+extras: Map<String, String>
+```
+
+{% endtab %}
+{% endtabs %}
 
 See the [Javadoc][36] for more information.
 


### PR DESCRIPTION
@radixdev thoughts on this? the method itself is defined in java, but could be useful to demonstrate the syntax that Kotlin users will use anyways, e.g.

```
val slideup = InAppMessageSlideup()
val extras = slideup.extras
```