### PR TITLE
Add kotlin to Setting User IDs page

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/android/analytics/setting_user_ids.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/analytics/setting_user_ids.md
@@ -24,9 +24,22 @@ These User IDs should be private and not easily obtained (e.g. not a plain email
 
 You should make the following call as soon as the user is identified (generally after logging in) in order to set the user id:
 
+{% tabs %}
+{% tab JAVA %}
+
 ```java
-Appboy.getInstance(YOUR_ACTIVITY.this).changeUser(YOUR_USER_ID_STRING);
+Appboy.getInstance(context).changeUser(YOUR_USER_ID_STRING);
 ```
+
+{% endtab %}
+{% tab KOTLIN %}
+
+```kotlin
+Appboy.getInstance(context).changeUser(YOUR_USER_ID_STRING)
+```
+
+{% endtab %}
+{% endtabs %}
 
 {% alert warning %}
 __Do not call `changeUser()` when a user logs out. `changeUser()` should only be called when the user logs into the application.__ Setting `changeUser()` to a static default value will associate ALL user activity with that default "user" until the user logs in again.

--- a/_includes/archive/aliasing.md
+++ b/_includes/archive/aliasing.md
@@ -26,9 +26,22 @@ Appboy.sharedInstance().user.addAlias(ALIAS_NAME, ALIAS_LABEL);
 
 {% elsif include.platform == "Android" %}
 
+{% tabs %}
+{% tab JAVA %}
+
 ```java
-Appboy.getInstance(YOUR_ACTIVITY.this).getCurrentUser().addAlias(ALIAS_NAME, ALIAS_LABEL);
+Appboy.getInstance(context).getCurrentUser().addAlias(ALIAS_NAME, ALIAS_LABEL);
 ```
+
+{% endtab %}
+{% tab KOTLIN %}
+
+```kotlin
+Appboy.getInstance(context).currentUser?.addAlias(ALIAS_NAME, ALIAS_LABEL)
+```
+
+{% endtab %}
+{% endtabs %}
 
 {% elsif include.platform == "Web" %}
 


### PR DESCRIPTION
Looking for feedback on
1) Pattern matching `context` on https://www.braze.com/docs/developer_guide/platform_integration_guides/android/content_cards/refreshing_the_feed/ (`YOUR_ACTIVITY.this` feels clunky and overly prescriptive)
2) `Appboy.getInstance(context).currentUser?` syntax