### PR TITLE
PC-1437 - Updated Android uninstall tracking docs to mention firebase messaging service

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/android/analytics/uninstall_tracking.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/analytics/uninstall_tracking.md
@@ -6,11 +6,11 @@ search_rank: 5
 ---
 ## Uninstall Tracking
 
-Uninstall Tracking utilizes a silent push from Firebase Cloud Messaging to detect uninstalled devices. However, If the app is still installed, then this silent push is received by your app. Starting in Braze Android SDK v3.1.0, we will intelligently drop the uninstall tracking notification and not wake up any custom broadcast receivers in your app with the regular silent push intent, [APPBOY_NOTIFICATION_OPENED_SUFFIX][5].
+Uninstall Tracking utilizes a silent push from Firebase Cloud Messaging to detect uninstalled devices. However, If the app is still installed, then this silent push is received by your app. Starting in Braze Android SDK v3.1.0, we will intelligently drop the uninstall tracking notification and not wake up any custom broadcast receivers in your app with the regular silent push intent.
 
-If you wish to detect if the push notification is uninstall tracking yourself, please use [`isUninstallTrackingPush()`][3].
+If you wish to detect if the push notification is uninstall tracking yourself, please use [`isUninstallTrackingPush()`][3]. Note that since uninstall tracking silent push is not forwarded to your custom broadcast receiver, this method can only used before the push notification is passed to Braze, such as when using a custom [Firebase Messaging Service][5].
 
-If you have a custom [`Application`][1] subclass, make sure you do not have automatic logic that pings your servers in your [`Application.onCreate()`][2] lifecycle method. This is because silent push will wake your app and instantiate an `Application` component, if it's not already running.
+If you have a custom [`Application`][1] subclass, make sure you do not have automatic logic that pings your servers in your [`Application.onCreate()`][2] lifecycle method. This is because silent push will wake your app and instantiate the [`Application`][1] component, if the app is not already running.
 
 For more information, see the [Uninstall Tracking][4] page in our User Guide.
 
@@ -18,4 +18,4 @@ For more information, see the [Uninstall Tracking][4] page in our User Guide.
 [2]: https://developer.android.com/reference/android/app/Application#onCreate()
 [3]: https://appboy.github.io/appboy-android-sdk/javadocs/com/appboy/push/AppboyNotificationUtils.html#isUninstallTrackingPush-android.os.Bundle-
 [4]: {{ site.baseurl }}/user_guide/data_and_analytics/tracking/uninstall_tracking/#uninstall-tracking
-[5]: https://appboy.github.io/appboy-android-sdk/javadocs/com/appboy/push/AppboyNotificationUtils.html#APPBOY_NOTIFICATION_OPENED_SUFFIX
+[5]: {{ site.baseurl }}/developer_guide/platform_integration_guides/android/push_notifications/integration/#step-1-register-braze-firebase-messaging-service

--- a/_docs/_developer_guide/platform_integration_guides/android/analytics/uninstall_tracking.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/analytics/uninstall_tracking.md
@@ -8,7 +8,11 @@ search_rank: 5
 
 Uninstall Tracking utilizes a silent push from Firebase Cloud Messaging to detect uninstalled devices. However, If the app is still installed, then this silent push is received by your app. Starting in Braze Android SDK v3.1.0, we will intelligently drop the uninstall tracking notification and not wake up any custom broadcast receivers in your app with the regular silent push intent.
 
-If you wish to detect if the push notification is uninstall tracking yourself, please use [`isUninstallTrackingPush()`][3]. Note that since uninstall tracking silent push is not forwarded to your custom broadcast receiver, this method can only used before the push notification is passed to Braze, such as when using a custom [Firebase Messaging Service][5].
+If you wish to detect if the push notification is uninstall tracking yourself, please use [`isUninstallTrackingPush()`][3]. 
+
+{% alert important %}
+Note that since uninstall tracking silent push is not forwarded to your custom broadcast receiver, this method can only used before the push notification is passed to Braze, such as when using a custom [Firebase Messaging Service][5].
+{% endalert %}
 
 If you have a custom [`Application`][1] subclass, make sure you do not have automatic logic that pings your servers in your [`Application.onCreate()`][2] lifecycle method. This is because silent push will wake your app and instantiate the [`Application`][1] component, if the app is not already running.
 


### PR DESCRIPTION
# Pull Request/Issue Resolution

**Description of Change:**
Updated android uninstall docs

**Reason for Change:**
Docs were out of date

### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Feature Release Date:__)
- [ ] No

> If yes, please note the date of the feature release.


---
---

## PR Checklist
- [ ] Ensure you have completed [our CLA](https://www.braze.com/docs/cla/).
- [ ] Tag @EmilyNecciai as a reviewer when the your work is _done and ready to be reviewed for merge_.
- [ ] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide).
- [ ] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices).
- [ ] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

## ATTENTION: REVIEWERS OF THIS PR
- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Preview all changes in the linked Heroku environment (click `View deployment` button below, then "Docs". A `502` error just means you should refresh until you see the Docs Home page.
---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
