### PR TITLE
Remove references to iOS versions before 3.0.0 + remove dry run reference

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/ios/advanced_use_cases/linking.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/advanced_use_cases/linking.md
@@ -238,13 +238,13 @@ For an implementation example, take a look at `application:openURL:options:` met
 
 ### Web View UI Customization
 
-Braze iOS SDK v.2.30.0 open sources the `ABKModalWebViewController` class, which is used to display web URLs from the SDK.
+The `ABKModalWebViewController` class, which is used to display web URLs from the SDK, is open source.
 
 You can declare a category for, or directly modify, the `ABKModalWebViewController` class to apply any UI customization to the web view. Please check the class's [.h file][6] and [.m file][5] for more detail.
 
 ### Linking Handling Customization
 
-Introduced in [SDK v.2.29.0][21], the `ABKURLDelegate` protocol can be used to customize handling of URIs such as deep links, web URLs and Universal Links. To set the delegate during Braze initialization, pass a delegate object to the `ABKURLDelegateKey` in the `appboyOptions` of [`startWithApiKey:inApplication:withAppboyOptions:`][22]. Braze will then call your delegate's implementation of `handleAppboyURL:fromChannel:withExtras:` before handling any URIs.
+The `ABKURLDelegate` protocol can be used to customize handling of URIs such as deep links, web URLs and Universal Links. To set the delegate during Braze initialization, pass a delegate object to the `ABKURLDelegateKey` in the `appboyOptions` of [`startWithApiKey:inApplication:withAppboyOptions:`][22]. Braze will then call your delegate's implementation of `handleAppboyURL:fromChannel:withExtras:` before handling any URIs.
 
 For more information, see [`ABKURLDelegate.h`][23].
 
@@ -346,7 +346,6 @@ func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpe
 [17]: http://timekl.com/blog/2015/08/21/shipping-an-app-with-app-transport-security/?utm_campaign=iOS+Dev+Weekly&utm_medium=email&utm_source=iOS_Dev_Weekly_Issue_213
 [19]: https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW33
 [20]: #customizing-link-handling
-[21]: https://github.com/Appboy/appboy-ios-sdk/blob/master/CHANGELOG.md#2290
 [22]: #customizing-appboy-on-startup
 [23]: https://github.com/Appboy/appboy-ios-sdk/blob/master/AppboyKit/headers/AppboyKitLibrary/ABKURLDelegate.h
 [24]: https://developer.apple.com/library/content/documentation/General/Conceptual/AppSearch/UniversalLinks.html

--- a/_docs/_developer_guide/platform_integration_guides/ios/advanced_use_cases/linking.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/advanced_use_cases/linking.md
@@ -236,11 +236,11 @@ For an implementation example, take a look at `application:openURL:options:` met
 
 ## Customization {#linking-customization}
 
-### Web View UI Customization
+### Default WebView Customization
 
-The `ABKModalWebViewController` class, which is used to display web URLs from the SDK, is open source.
+The open-source `ABKModalWebViewController` class is used to display web URLs opened by the SDK, typically when "Open Web URL Inside App" is selected for a web deep link.
 
-You can declare a category for, or directly modify, the `ABKModalWebViewController` class to apply any UI customization to the web view. Please check the class's [.h file][6] and [.m file][5] for more detail.
+You can declare a category for, or directly modify, the `ABKModalWebViewController` class to apply customization to the web view. Please check the class's [.h file][6] and [.m file][5] for more detail.
 
 ### Linking Handling Customization
 

--- a/_docs/_developer_guide/platform_integration_guides/ios/advanced_use_cases/localization.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/advanced_use_cases/localization.md
@@ -6,7 +6,7 @@ search_rank: 5
 ---
 # Localization
 
-Localization is supported in version 2.5+ of the Braze iOS SDK. In addition to English, Braze supports 29 languages in our built-in SDK messages. These pertain to the default messages displayed in applications integrated with Braze, such as places in the app when there are connectivity issues ("Cannot establish network connection. Please try again later.") See below for a full list of messages (strings). If the phone language is set to one of the supported languages, any of the Braze default strings triggered within an integrated application will automatically appear in that language.
+In addition to English, Braze supports 29 languages in our built-in SDK messages. These pertain to the default messages displayed in applications integrated with Braze, such as places in the app when there are connectivity issues ("Cannot establish network connection. Please try again later.") See below for a full list of messages (strings). If the phone language is set to one of the supported languages, any of the Braze default strings triggered within an integrated application will automatically appear in that language.
 
 ## Languages Supported
 1. Arabic

--- a/_docs/_developer_guide/platform_integration_guides/ios/push_notifications/action_buttons.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/push_notifications/action_buttons.md
@@ -11,7 +11,7 @@ Users may interact with your application via notification [categories][14]. Cate
 
 ![Illustration of Notification Action][13]
 
-iOS SDK version 2.27.0 introduced default Braze push categories, including URL handling support for each push action button. Currently, the default categories have four sets of push action buttons: `Accept`/`Decline`, `Yes`/`No`, `Confirm`/`Cancel` and `More`. To register Braze's default push categories, follow the integration instructions below:
+The Braze iOS SDK supports default push categories, including URL handling support for each push action button. Currently, the default categories have four sets of push action buttons: `Accept`/`Decline`, `Yes`/`No`, `Confirm`/`Cancel` and `More`. To register Braze's default push categories, follow the integration instructions below:
 
 ## Step 1: Adding Braze Default Push Categories
 

--- a/_docs/_developer_guide/platform_integration_guides/ios/push_notifications/troubleshooting.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/push_notifications/troubleshooting.md
@@ -18,7 +18,7 @@ There are two types of provisioning profiles and certificates - development and 
 
 #### Step 2: Devices register for APNs and provide Braze with push tokens
 
-When users open your app, they will be prompted to accept push notifications. If they accept this prompt, then APNs will generate a push token for that particular device. As of SDK version 2.21.0, the iOS SDK will immediately and asynchronously send up the push token for apps using the default [Automatic Flush Policy][40].  After we have a push token associated with a user, they will show as "Push Registered" in the dashboard on their user profile under the "Engagement" tab and will be eligible to receive push notifications from Braze campaigns.
+When users open your app, they will be prompted to accept push notifications. If they accept this prompt, then APNs will generate a push token for that particular device. The iOS SDK will immediately and asynchronously send up the push token for apps using the default [Automatic Flush Policy][40].  After we have a push token associated with a user, they will show as "Push Registered" in the dashboard on their user profile under the "Engagement" tab and will be eligible to receive push notifications from Braze campaigns.
 
 > This does not work with the iOS Simulator. You cannot test push notifications with the iOS Simulator as a result.
 
@@ -129,8 +129,6 @@ Most of the code that handles deep links also handles push opens.  First, ensure
 
 If opens are being logged, check to see if it is an issue with the deep link in general or with the deep linking push click handling.  To do this, test to see if a deep link from an In-App Message click works.
 
-If deep links are working normally and opens are working, but deep links don’t work from our push clicks, check what version of the SDK you are on. In 2.21.0 we required deep links to be whitelisted in order to function properly.  We removed this in 2.24.2.  If the issue is happening on a version in between, ensure that the deep link is [whitelisted][39].
-
 [1]: {% image_buster /assets/img_archive/push_changelog.png %}
 [20]: https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/APNSOverview.html#//apple_ref/doc/uid/TP40008194-CH8-SW1
 [21]: {{ site.baseurl }}/developer_guide/platform_integration_guides/ios/push_notifications/integration/
@@ -150,5 +148,4 @@ If deep links are working normally and opens are working, but deep links don’t
 [35]: #received-unregistered-sending
 [37]: {{ site.baseurl }}/developer_guide/platform_integration_guides/ios/push_notifications/integration/#step-4-register-push-tokens-with-braze
 [38]: {{ site.baseurl }}/developer_guide/platform_integration_guides/ios/advanced_use_cases/linking/#app-transport-security-ats
-[39]: {{ site.baseurl }}/developer_guide/platform_integration_guides/ios/advanced_use_cases/linking/#deep-links
 [40]: {{ site.baseurl }}/developer_guide/platform_integration_guides/ios/advanced_use_cases/fine_network_traffic_control/#automatic-request-processing

--- a/_docs/_user_guide/data_and_analytics/tracking/uninstall_tracking.md
+++ b/_docs/_user_guide/data_and_analytics/tracking/uninstall_tracking.md
@@ -21,7 +21,7 @@ You can enable Uninstall Tracking in the App Settings section of the "Manage App
 
 ![Uninstall Tracking Checkbox][1]
 
-When uninstall tracking is enabled for an app, background push messages will be sent nightly to users who have not recorded a session or received a push in 24 hours. If you are interested in filtering Braze background push on iOS, you can use the utility method that was released in [iOS SDK version 2.13][iOS]; documentation for this methods can be found [here][iOS docs]. On Android, we are able to utilize Firebase Cloud Messaging's "dry run" feature to perform Uninstall Tracking without actually sending a notification to the device, and so filtering Braze uninstall background push is therefore unnecessary on Android. When Braze detects an uninstall, whether from Uninstall Tracking or normal push campaign delivery, we will record the best estimated time of the uninstall on the user. This time is stored in the user profile as a standard attribute.
+When uninstall tracking is enabled for an app, background push messages will be sent nightly to users who have not recorded a session or received a push in 24 hours. If you are interested in filtering Braze background push on iOS, you can use a [utility method][iOS docs]. On Android, you can use [`AppboyNotificationUtils.isUninstallTrackingPush()`][8] to detect uninstall push. When Braze detects an uninstall, whether from Uninstall Tracking or normal push campaign delivery, we will record the best estimated time of the uninstall on the user. This time is stored in the user profile as a standard attribute.
 
 ![Uninstall Attribute][4]
 
@@ -53,8 +53,6 @@ Braze tracks uninstalls by observing when push messages sent to users’ devices
 
 Uninstall Tracking is subject to restrictions placed on this information by FCM and APNs. Braze only increments the uninstall count when FCM or APNs tells us that a user has uninstalled, but these third-party systems reserve the right to notify us of uninstalls at any point in time. As a result, Uninstall Tracking should be used to detect directional trends as opposed to precise statistics.
 
-To enable Uninstall Tracking, your user base should be on at least iOS SDK version 2.13. Turning on Uninstall Tracking for apps with users below this SDK version will send blank pushes to end users.
-
 For more on using Uninstall Tracking, see [this blog post][7].
 
 Uninstall statistics for campaigns are located on the Campaign Details page. For multichannel and multivariate campaigns, uninstalls can be broken down by channel and variant, respectively.
@@ -66,7 +64,7 @@ Uninstall statistics for campaigns are located on the Campaign Details page. For
 [3]: {% image_buster /assets/img_archive/Uninstall_232.png %} "Uninstall Graph"
 [4]: {% image_buster /assets/img_archive/User_Profile.png %} "Uninstall Attribute"
 [5]: {% image_buster /assets/img_archive/Uninstall_Segment.png %} "Uninstall Segment"
-[7]: https://www.braze.com/blog/uninstall-tracking-an-industry-look-at-its-strengths-and-limitations/
-[iOS]: https://github.com/appboy/appboy-ios-sdk/blob/master/CHANGELOG.md "iOS Changelog"
-[iOS docs]: {{ site.baseurl }}/developer_guide/platform_integration_guides/ios/analytics/uninstall_tracking/
 [6]: {% image_buster /assets/img_archive/campaign_level_uninstall_tracking.png %}
+[7]: https://www.braze.com/blog/uninstall-tracking-an-industry-look-at-its-strengths-and-limitations/
+[iOS docs]: {{ site.baseurl }}/developer_guide/platform_integration_guides/ios/analytics/uninstall_tracking/
+[8]: https://appboy.github.io/appboy-android-sdk/javadocs/com/appboy/push/AppboyNotificationUtils.html#isUninstallTrackingPush-android.os.Bundle-


### PR DESCRIPTION
Note that the docs no longer claim we use dry run or not based on the fact that both are theoretically possible.