### PR TITLE
Move location enabling docs to initial sdk setup

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/android/advanced_use_cases/locations_and_geofences.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/advanced_use_cases/locations_and_geofences.md
@@ -61,7 +61,7 @@ If you are using a version of the Android SDK less than `2.3.0`, the following m
 
 ### Step 3: Enable Braze Location Collection
 
-If you have not yet enabled Braze location collection, update your `appboy.xml` file to include `com_appboy_enable_location_collection` and ensure its value is set to true.
+If you have not yet enabled Braze location collection, update your `appboy.xml` file to include `com_appboy_enable_location_collection` and ensure its value is set to `true`.
 
 ```xml
 <bool name="com_appboy_enable_location_collection">true</bool>
@@ -71,7 +71,7 @@ If you have not yet enabled Braze location collection, update your `appboy.xml` 
 Starting with Braze Android SDK version 3.6.0 Braze location collection is disabled by default.
 {% endalert %}
 
-Braze geofences are enabled if Braze location collection is enabled. If you would like to opt-out of our default location collection but still want to use geofences, it can be enabled selectively by setting the value of key `com_appboy_geofences_enabled` to true in `appboy.xml`, independently of the value of `com_appboy_enable_location_collection`. 
+Braze geofences are enabled if Braze location collection is enabled. If you would like to opt-out of our default location collection but still want to use geofences, it can be enabled selectively by setting the value of key `com_appboy_geofences_enabled` to `true` in `appboy.xml`, independently of the value of `com_appboy_enable_location_collection`. 
 
 ```xml
 <bool name="com_appboy_geofences_enabled">true</bool>

--- a/_docs/_developer_guide/platform_integration_guides/android/advanced_use_cases/locations_and_geofences.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/advanced_use_cases/locations_and_geofences.md
@@ -60,7 +60,8 @@ If you are using a version of the Android SDK less than `2.3.0`, the following m
 {% endalert %}
 
 ### Step 3: Enable Braze Location Collection
-To enable Braze location collection, update your `appboy.xml` file to include `com_appboy_enable_location_collection` and ensure its value is set to true.
+
+If you have not yet enabled Braze location collection, update your `appboy.xml` file to include `com_appboy_enable_location_collection` and ensure its value is set to true.
 
 ```xml
 <bool name="com_appboy_enable_location_collection">true</bool>

--- a/_docs/_developer_guide/platform_integration_guides/android/initial_sdk_setup/android_sdk_integration.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/initial_sdk_setup/android_sdk_integration.md
@@ -144,7 +144,7 @@ The SDK Endpoint configuration via `appboy.xml` is available starting with __Bra
 
 ### Step 6: Enable Location Tracking
 
-If you would like to enable Braze location collection, update your `appboy.xml` file to include `com_appboy_enable_location_collection` and ensure its value is set to true.
+If you would like to enable Braze location collection, update your `appboy.xml` file to include `com_appboy_enable_location_collection` and ensure its value is set to `true`.
 
 ```xml
 <bool name="com_appboy_enable_location_collection">true</bool>

--- a/_docs/_developer_guide/platform_integration_guides/android/initial_sdk_setup/android_sdk_integration.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/initial_sdk_setup/android_sdk_integration.md
@@ -142,6 +142,18 @@ To update the default endpoint in your integration of the Braze SDKs please add 
 
 The SDK Endpoint configuration via `appboy.xml` is available starting with __Braze Android SDK v2.1.1__.
 
+### Step 6: Enable Location Tracking
+
+If you would like to enable Braze location collection, update your `appboy.xml` file to include `com_appboy_enable_location_collection` and ensure its value is set to true.
+
+```xml
+<bool name="com_appboy_enable_location_collection">true</bool>
+```
+
+{% alert important %}
+Starting with Braze Android SDK version 3.6.0 Braze location collection is disabled by default.
+{% endalert %}
+
 ### SDK Integration Complete
 
 Braze will now be able to collect [specified data from your application]({{ site.baseurl }}/user_guide/data_and_analytics/user_data_collection/overview/) and your basic integration should be complete.

--- a/_docs/_developer_guide/platform_integration_guides/fireos/advanced_use_cases/locations_and_geofences.md
+++ b/_docs/_developer_guide/platform_integration_guides/fireos/advanced_use_cases/locations_and_geofences.md
@@ -57,7 +57,7 @@ declaration is also required:
 
 ### Step 3: Enable Braze Location Collection
 
-To enable Braze location collection, update your `appboy.xml` file to include `com_appboy_enable_location_collection` and ensure its value is set to true.
+If you have not yet enabled Braze location collection, update your `appboy.xml` file to include `com_appboy_enable_location_collection` and ensure its value is set to true.
 
 ```xml
 <bool name="com_appboy_enable_location_collection">true</bool>

--- a/_docs/_developer_guide/platform_integration_guides/fireos/advanced_use_cases/locations_and_geofences.md
+++ b/_docs/_developer_guide/platform_integration_guides/fireos/advanced_use_cases/locations_and_geofences.md
@@ -57,7 +57,7 @@ declaration is also required:
 
 ### Step 3: Enable Braze Location Collection
 
-If you have not yet enabled Braze location collection, update your `appboy.xml` file to include `com_appboy_enable_location_collection` and ensure its value is set to true.
+If you have not yet enabled Braze location collection, update your `appboy.xml` file to include `com_appboy_enable_location_collection` and ensure its value is set to `true`.
 
 ```xml
 <bool name="com_appboy_enable_location_collection">true</bool>
@@ -67,7 +67,7 @@ If you have not yet enabled Braze location collection, update your `appboy.xml` 
 Starting with Braze Android SDK version 3.6.0 Braze location collection is disabled by default.
 {% endalert %}
 
-Braze geofences are enabled if Braze location collection is enabled. If you would like to opt-out of our default location collection but still want to use geofences, it can be enabled selectively by setting the value of key `com_appboy_geofences_enabled` to true in `appboy.xml`, independently of the value of `com_appboy_enable_location_collection`. 
+Braze geofences are enabled if Braze location collection is enabled. If you would like to opt-out of our default location collection but still want to use geofences, it can be enabled selectively by setting the value of key `com_appboy_geofences_enabled` to `true` in `appboy.xml`, independently of the value of `com_appboy_enable_location_collection`. 
 
 ```xml
 <bool name="com_appboy_geofences_enabled">true</bool>

--- a/_docs/_developer_guide/platform_integration_guides/fireos/initial_sdk_setup.md
+++ b/_docs/_developer_guide/platform_integration_guides/fireos/initial_sdk_setup.md
@@ -122,6 +122,18 @@ To update the default endpoint in your integration of the Braze SDKs please add 
 
 SDK Endpoint configuration via `appboy.xml` is available starting with Braze Android SDK v2.1.1.
 
+### Step 6: Enable Location Tracking
+
+If you would like to enable Braze location collection, update your `appboy.xml` file to include `com_appboy_enable_location_collection` and ensure its value is set to true.
+
+```xml
+<bool name="com_appboy_enable_location_collection">true</bool>
+```
+
+{% alert important %}
+Starting with Braze Android SDK version 3.6.0 Braze location collection is disabled by default.
+{% endalert %}
+
 ### SDK Integration Complete
 Braze will now be able to collect [specified data from your application]({{ site.baseurl }}/user_guide/data_and_analytics/user_data_collection/overview/) and your basic integration should be complete.
 

--- a/_docs/_developer_guide/platform_integration_guides/fireos/initial_sdk_setup.md
+++ b/_docs/_developer_guide/platform_integration_guides/fireos/initial_sdk_setup.md
@@ -124,7 +124,7 @@ SDK Endpoint configuration via `appboy.xml` is available starting with Braze And
 
 ### Step 6: Enable Location Tracking
 
-If you would like to enable Braze location collection, update your `appboy.xml` file to include `com_appboy_enable_location_collection` and ensure its value is set to true.
+If you would like to enable Braze location collection, update your `appboy.xml` file to include `com_appboy_enable_location_collection` and ensure its value is set to `true`.
 
 ```xml
 <bool name="com_appboy_enable_location_collection">true</bool>


### PR DESCRIPTION
Currently they're buried in Geofences docs, which isnt ideal since location collection is relevant to more than just geofence implementors