### PR TITLE
BD-222 : Content Cards Custom Language

### DIFF
--- a/_docs/_user_guide/message_building_by_channel/content_cards/customize.md
+++ b/_docs/_user_guide/message_building_by_channel/content_cards/customize.md
@@ -18,3 +18,17 @@ guide_featured_list:
   fa_icon: fas fa-globe
 ---
 <br>
+
+## Change "Empty Feed" Language
+
+You can change the language that appears automatically in your Content Card feeds by [redefining the localizable content card strings](https://github.com/Appboy/appboy-ios-sdk/blob/3cca65b06f66085f5bc7c8e1ad267bf8bb1f0da7/AppboyUI/ABKContentCards/Resources/en.lproj/AppboyContentCardsLocalizable.strings) in your app’s localizable strings file: 
+```
+"Appboy.content-cards.no-card.text" = "No Cards!!!!";
+"Appboy.content-cards.done-button.title" = "Done";
+"Appboy.content-cards.no-card.text" = "We have no updates.\nPlease check again later.";
+"Appboy.content-cards.no-connection.title" = "Connection Error";
+"Appboy.content-cards.no-connection.message" = "Cannot establish network connection.\nPlease try again later.";
+```
+{% alert note %}
+If you want to update it for different languages, find the corresponding language in [the Resources folder structure](https://github.com/Appboy/appboy-ios-sdk/tree/3cca65b06f66085f5bc7c8e1ad267bf8bb1f0da7/AppboyUI/ABKContentCards/Resources) with the same string `Appboy.content-cards.no-card.text`.
+{% endalert %}

--- a/_docs/_user_guide/message_building_by_channel/content_cards/customize.md
+++ b/_docs/_user_guide/message_building_by_channel/content_cards/customize.md
@@ -21,7 +21,7 @@ guide_featured_list:
 
 ## Change "Empty Feed" Language
 
-You can change the language that appears automatically in your Content Card feeds by [redefining the localizable content card strings](https://github.com/Appboy/appboy-ios-sdk/blob/3cca65b06f66085f5bc7c8e1ad267bf8bb1f0da7/AppboyUI/ABKContentCards/Resources/en.lproj/AppboyContentCardsLocalizable.strings) in your app’s localizable strings file: 
+You can change the language that appears automatically in empty Content Card feeds by [redefining the localizable content card strings](https://github.com/Appboy/appboy-ios-sdk/blob/3cca65b06f66085f5bc7c8e1ad267bf8bb1f0da7/AppboyUI/ABKContentCards/Resources/en.lproj/AppboyContentCardsLocalizable.strings) in your app’s localizable strings file: 
 ```
 "Appboy.content-cards.no-card.text" = "No Cards!!!!";
 "Appboy.content-cards.done-button.title" = "Done";


### PR DESCRIPTION
# Pull Request/Issue Resolution

**Description of Change:**
> how to change language to indicate no cards	
 

**Reason for Change:**
> I'm making this change because.....


Closes #**ISSUE_NUMBER_HERE**

### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Feature Release Date:__)
- [ ] No

> If yes, please note the date of the feature release.


---
---

## PR Checklist
- [ ] Ensure you have completed [our CLA](https://www.braze.com/docs/cla/).
- [ ] Tag @EmilyNecciai as a reviewer when the your work is _done and ready to be reviewed for merge_.
- [ ] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide).
- [ ] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices).
- [ ] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

## ATTENTION: REVIEWERS OF THIS PR
- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Preview all changes in the linked Heroku environment (click `View deployment` button below, then "Docs". A `502` error just means you should refresh until you see the Docs Home page.
---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
