### PR TITLE
added content cards docs on disabling swipe to dismiss

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/android/content_cards/customization.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/content_cards/customization.md
@@ -488,6 +488,10 @@ You can manually log or set a Content Card as "dismissed" to Braze [for a partic
 
 If a card is already marked as dismissed, it cannot be marked as dismissed again.
 
+## Disabling Swipe To Dismiss
+
+Disabling swipe-to-dismiss functionality is done on a per-card basis via the [`card.setIsDismissibleByUser()`][48] method. Cards can be intercepted before display in the [`AppboyContentCardsFragment.setContentCardUpdateHandler()`][45] method.
+
 ## Key-Value Pairs
 `Card` objects may optionally carry key-value pairs as `extras`. These can be used to send data down along with a `Card` for further handling by the application.
 
@@ -534,3 +538,4 @@ See the [Javadoc][36] for more information.
 [45]: https://appboy.github.io/appboy-android-sdk/javadocs/com/appboy/ui/AppboyContentCardsFragment.html#setContentCardUpdateHandler-com.appboy.ui.contentcards.handlers.IContentCardsUpdateHandler-
 [46]: https://github.com/Appboy/appboy-android-sdk/blob/v3.4.0/android-sdk-ui/src/main/java/com/appboy/ui/contentcards/handlers/DefaultContentCardsUpdateHandler.java
 [47]: https://appboy.github.io/appboy-android-sdk/javadocs/com/appboy/ui/AppboyContentCardsFragment.html
+[48]: https://appboy.github.io/appboy-android-sdk/javadocs/com/appboy/models/cards/Card.html#setIsDismissibleByUser-boolean-

--- a/_docs/_developer_guide/platform_integration_guides/android/content_cards/customization.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/content_cards/customization.md
@@ -490,7 +490,7 @@ If a card is already marked as dismissed, it cannot be marked as dismissed again
 
 ## Disabling Swipe To Dismiss
 
-Disabling swipe-to-dismiss functionality is done on a per-card basis via the [`card.setIsDismissibleByUser()`][48] method. Cards can be intercepted before display in the [`AppboyContentCardsFragment.setContentCardUpdateHandler()`][45] method.
+Disabling swipe-to-dismiss functionality is done on a per-card basis via the [`card.setIsDismissibleByUser()`][48] method. Cards can be intercepted before display using the [`AppboyContentCardsFragment.setContentCardUpdateHandler()`][45] method.
 
 ## Key-Value Pairs
 `Card` objects may optionally carry key-value pairs as `extras`. These can be used to send data down along with a `Card` for further handling by the application.


### PR DESCRIPTION
# Pull Request/Issue Resolution

**Description of Change:**
Docs on how to disable the default swipe to dismiss functionality


**Reason for Change:**
> I'm making this change because.....


Closes #**ISSUE_NUMBER_HERE**

### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Feature Release Date:__)
- [ ] No

> If yes, please note the date of the feature release.


---
---

## PR Checklist
- [ ] Ensure you have completed [our CLA](https://www.braze.com/docs/cla/).
- [ ] Tag @EmilyNecciai as a reviewer when the your work is _done and ready to be reviewed for merge_.
- [ ] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide).
- [ ] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices).
- [ ] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

## ATTENTION: REVIEWERS OF THIS PR
- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Preview all changes in the linked Heroku environment (click `View deployment` button below, then "Docs". A `502` error just means you should refresh until you see the Docs Home page.
---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
