### PR TITLE
Adding Dark Mode Block to IAM main page

### DIFF
--- a/_docs/_user_guide/message_building_by_channel/in-app_messages.md
+++ b/_docs/_user_guide/message_building_by_channel/in-app_messages.md
@@ -9,7 +9,7 @@ guide_featured_title: "Popular Articles"
 guide_featured_list:
 - name: Creating an In-App Message
   link: /docs/user_guide/message_building_by_channel/in-app_messages/create/
-  fa_icon: fas fa-mobile
+  fa_icon: fas fa-mobile-alt
 - name: Creative Details
   link: /docs/user_guide/message_building_by_channel/in-app_messages/creative_details/
   fa_icon: fas fa-paint-brush
@@ -22,6 +22,10 @@ guide_featured_list:
 - name: "Reporting & Analytics"
   link: /docs/user_guide/message_building_by_channel/in-app_messages/reporting/
   fa_icon: fas fa-chart-bar
+- name: "Dark Mode"
+  link: /docs/user_guide/message_building_by_channel/in-app_messages/dark-mode/
+  fa_icon: fas fa-mobile
+
 ---
 
 To see examples of in-app messages, check out our [Client Integration Gallery][11].


### PR DESCRIPTION
# Pull Request/Issue Resolution

**Description of Change:**
> I'm adding the dark mode block to the IAM main page now that dark mode docs are no longer hidden

**Reason for Change:**
> I'm making this change because #679 


Closes #**ISSUE_NUMBER_HERE**

### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Feature Release Date:__)
- [ ] No

> If yes, please note the date of the feature release.


---
---

## PR Checklist
- [ ] Ensure you have completed [our CLA](https://www.braze.com/docs/cla/).
- [ ] Tag @EmilyNecciai as a reviewer when the your work is _done and ready to be reviewed for merge_.
- [ ] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide).
- [ ] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices).
- [ ] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

## ATTENTION: REVIEWERS OF THIS PR
- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Preview all changes in the linked Heroku environment (click `View deployment` button below, then "Docs". A `502` error just means you should refresh until you see the Docs Home page.
---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
