### PR TITLE
[PC-1646] update action buttons docs

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/ios/push_notifications/action_buttons.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/push_notifications/action_buttons.md
@@ -104,7 +104,7 @@ Appboy.sharedInstance()?.getActionWithIdentifier(identifier,
 {% endtabs %}
 
 
-> We strongly reccomend that people using `handleActionWithIdentifier` begin using UNNotification Framework.
+> We strongly recommend that people using `handleActionWithIdentifier` begin using UNNotification Framework.
 
 
 

--- a/_docs/_developer_guide/platform_integration_guides/ios/push_notifications/action_buttons.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/push_notifications/action_buttons.md
@@ -104,7 +104,7 @@ Appboy.sharedInstance()?.getActionWithIdentifier(identifier,
 {% endtabs %}
 
 
-> We strongly recommend that people using `handleActionWithIdentifier` begin using UNNotification Framework.
+> We strongly recommend that people using `handleActionWithIdentifier` begin using UNNotification Framework. We recommend this due to the [deprecation of handleActionWithIdentifier][40].
 
 
 
@@ -138,3 +138,4 @@ Appboy.sharedInstance()?.getActionWithIdentifier(identifier,
 [37]: {{ site.baseurl }}/developer_guide/platform_integration_guides/ios/push_notifications/customization/#push-action-buttons-customization
 [38]: https://github.com/Appboy/appboy-ios-sdk/blob/master/HelloSwift/HelloSwiftNotificationExtension/NotificationService.swift
 [39]: {{ site.baseurl }}/developer_guide/platform_integration_guides/ios/push_notifications/integration/#step-5-enable-push-handling
+[40]: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623068-application?language=objc

--- a/_docs/_developer_guide/platform_integration_guides/ios/push_notifications/action_buttons.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/push_notifications/action_buttons.md
@@ -80,6 +80,32 @@ Appboy.sharedInstance()?.userNotificationCenter(center,
 {% endtab %}
 {% endtabs %}
 
+If you are not using UNNotification Framework you will need to add the following code to your app's `application:handleActionWithIdentifier:forRemoteNotification:completionHandler:` to enable Braze's push action button handling:
+
+{% tabs %}
+{% tab OBJECTIVE-C %}
+
+```objc
+[[Appboy sharedInstance] getActionWithIdentifier:identifier
+                           forRemoteNotification:userInfo
+                               completionHandler:completionHandler];
+```
+
+{% endtab %}
+{% tab swift %}
+
+```swift
+Appboy.sharedInstance()?.getActionWithIdentifier(identifier,
+                                                 forRemoteNotification: userInfo,,
+                                                 completionHandler: completionHandler)
+```
+
+{% endtab %}
+{% endtabs %}
+
+
+> We strongly reccomend that people using `handleActionWithIdentifier` begin using UNNotification Framework.
+
 
 
 [0]: {{ site.baseurl }}/developer_guide/platform_integration_guides/ios/push_notifications/troubleshooting/

--- a/_docs/_developer_guide/platform_integration_guides/ios/push_notifications/action_buttons.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/push_notifications/action_buttons.md
@@ -49,7 +49,7 @@ UIApplication.shared.registerUserNotificationSettings(settings)
 {% endtab %}
 {% endtabs %}
 
->  Clicking on push action buttons with background activation mode will only dismiss the notification and will not open the app. Button click analytics for these actions will be flushed to the server the next time the user opens the app.
+Clicking on push action buttons with background activation mode will only dismiss the notification and will not open the app. Button click analytics for these actions will be flushed to the server the next time the user opens the app.
 
 >  If you wish to create your own custom notification categories, see our [action button customization][37] documentation.
 
@@ -57,7 +57,9 @@ See our sample code [here][33] for `UserNotification.framework` and [here][32] f
 
 ## Step 2: Enable Interactive Push Handling
 
-If you are using the UNNotification Framework and have implemented [Braze delegates][39], you should already have this method integrated. To enable Braze's push action button handling, including click analytics and URL routing, add the following code to your app's `(void)userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:` delegate method:
+If you are using the UNNotification Framework and have implemented [Braze delegates][39], you should already have this method integrated. 
+
+To enable Braze's push action button handling, including click analytics and URL routing, add the following code to your app's `(void)userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:` delegate method:
 
 {% tabs %}
 {% tab OBJECTIVE-C %}
@@ -103,8 +105,11 @@ Appboy.sharedInstance()?.getActionWithIdentifier(identifier,
 {% endtab %}
 {% endtabs %}
 
+{% alert important %}
+We strongly recommend that people using `handleActionWithIdentifier` begin using UNNotification Framework. We recommend this due to the [deprecation of handleActionWithIdentifier](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623068-application?language=objc).
+{% endalert %}
 
-> We strongly recommend that people using `handleActionWithIdentifier` begin using UNNotification Framework. We recommend this due to the [deprecation of handleActionWithIdentifier][40].
+<br>
 
 
 


### PR DESCRIPTION
getActionWithIdentifier (to handle push notification action) which is currently deprecated, therefore we want to recommend users who use notification actions to implement the user notification framework.

The documentation should say to use didReceiveNotificationResponse:response IF users are using user notification framework for handling push. However, if not using user notification framework, getActionWithIdentifier is still required