### PR TITLE
Updated users/alias/new

### DIFF
--- a/_docs/_api/endpoints/user_data.md
+++ b/_docs/_api/endpoints/user_data.md
@@ -456,9 +456,7 @@ Content-Type: application/json
 
 ```json
 {
-  "external_id" : (required, string) see External User ID below,
-  // external_ids for users that do not exist will return a non-fatal error. 
-  // (See Server Responses for details.)
+  "external_id" : (optional, string) see External User ID below,
   // If an external_id is not present, a user will still be created, but needs to be identified down the road 
   // (See "Identifying Users" and the `users/identify` endpoint below.)
   "alias_name" : (required, string),


### PR DESCRIPTION
We don't want to say the external_id is required anymore right since you can create an alias without an external_id now?

# Pull Request/Issue Resolution

**Description of Change:**
> I'm changing the New User Alias Object Specification so that external_id is no longer required.


**Reason for Change:**
> I'm making this change because it can be confusing for clients when understanding this API spec.


Closes #**ISSUE_NUMBER_HERE**

### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Feature Release Date:__)
- [ ] No

> If yes, please note the date of the feature release.


---
---

## PR Checklist
- [ ] Ensure you have completed [our CLA](https://www.braze.com/docs/cla/).
- [ ] Tag @EmilyNecciai as a reviewer when the your work is _done and ready to be reviewed for merge_.
- [ ] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide).
- [ ] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices).
- [ ] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

## ATTENTION: REVIEWERS OF THIS PR
- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Preview all changes in the linked Heroku environment (click `View deployment` button below, then "Docs". A `502` error just means you should refresh until you see the Docs Home page.
---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
