### PR TITLE
BD-293

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/android/content_cards/customization.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/content_cards/customization.md
@@ -499,6 +499,10 @@ See the [Javadoc][36] for more information.
 
 ## GIFs {#gifs-news-content-cards}
 
+ {% alert note %}
+ Content Cards have a maximum size of __2kb__ (including images, links, and all content) - anything that exceeds that amount will cause an error and prevent the card from sending.
+ {% endalert %}
+
 {% include archive/android/gifs.md channel="Content Cards" %}
 
 [2]: http://developer.android.com/guide/components/fragments.html

--- a/_docs/_developer_guide/platform_integration_guides/android/content_cards/overview.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/content_cards/overview.md
@@ -31,7 +31,7 @@ Braze recommends that customers who use our News Feed tool move over to our Cont
  ![Content Cards Feed]({% image_buster /assets/img/sample-torchy-feed-content-cards-braze.png %}){: height="50%" width="50%"}
 
  {% alert note %}
- Content Cards have a maximum size of 2kb (including images, links, and all content) - anything that exceeds that amount will cause an error and prevent the card from sending.
+ Content Cards have a maximum size of __2kb__ (including images, links, and all content) - anything that exceeds that amount will cause an error and prevent the card from sending.
  {% endalert %}
 
 

--- a/_docs/_developer_guide/platform_integration_guides/android/content_cards/overview.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/content_cards/overview.md
@@ -30,6 +30,11 @@ Braze recommends that customers who use our News Feed tool move over to our Cont
 
  ![Content Cards Feed]({% image_buster /assets/img/sample-torchy-feed-content-cards-braze.png %}){: height="50%" width="50%"}
 
+ {% alert note %}
+ Content Cards have a maximum size of 2kb (including images, links, and all content) - anything that exceeds that amount will cause an error and prevent the card from sending.
+ {% endalert %}
+
+
 ## Content Cards Integration Overview {#content-cards-integration-for-android}
 
  In Android, the Content Cards feed is implemented as a [Fragment][2] that are available in the Braze Android UI project. View [Google's documentation on Fragments][3] for information on how to add a Fragment to an Activity.

--- a/_docs/_developer_guide/platform_integration_guides/ios/content_cards/customization.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/content_cards/customization.md
@@ -81,6 +81,10 @@ Braze allows clients to replace existing default images with their own custom im
 
 {% alert note %} Be sure to upload the `@2x` and `@3x` versions of the images as well to accommodate different phone sizes. {% endalert %}
 
+ {% alert note %}
+ Content Cards have a maximum size of __2kb__ (including images, links, and all content) - anything that exceeds that amount will cause an error and prevent the card from sending.
+ {% endalert %}
+
 ## Customizing the Content Cards Feed
 
 You can create your own Content Cards interface by extending `ABKContentCardsTableViewController` to customize all UI elements and Content Cards behavior. Alternatively, you can create a completely custom view controller and subscribe for data updates. In the latter case, you would need to log all view events, dismissed events, and clicks manually.

--- a/_docs/_developer_guide/platform_integration_guides/ios/content_cards/overview.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/content_cards/overview.md
@@ -23,4 +23,7 @@ search_rank: 5
  This is what it looks like for your users to open a basic Content Card feed. There are three basic types of cards that can sit in the feed - a Banner Card, a Captioned Content Card, and a Classic Content Card.
 
  ![Content Cards Feed]({% image_buster /assets/img/sample-torchy-feed-content-cards-braze.png %}){: height="50%" width="50%"}
-s
+
+ {% alert note %}
+ Content Cards have a maximum size of __2kb__ (including images, links, and all content) - anything that exceeds that amount will cause an error and prevent the card from sending.
+ {% endalert %}

--- a/_docs/_developer_guide/platform_integration_guides/ios/content_cards/overview.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/content_cards/overview.md
@@ -23,3 +23,4 @@ search_rank: 5
  This is what it looks like for your users to open a basic Content Card feed. There are three basic types of cards that can sit in the feed - a Banner Card, a Captioned Content Card, and a Classic Content Card.
 
  ![Content Cards Feed]({% image_buster /assets/img/sample-torchy-feed-content-cards-braze.png %}){: height="50%" width="50%"}
+s

--- a/_docs/_developer_guide/platform_integration_guides/web/content_cards/overview.md
+++ b/_docs/_developer_guide/platform_integration_guides/web/content_cards/overview.md
@@ -31,6 +31,6 @@ This is what it looks like for your users to open a basic Content Card feed. As 
 ![Content Cards Feed]({% image_buster /assets/img/cc-feed_web.png %}){: height="50%" width="50%"}
 
  {% alert note %}
- Content Cards have a maximum size of 2kb (including images, links, and all content) - anything that exceeds that amount will cause an error and prevent the card from sending.
+ Content Cards have a maximum size of __2kb__ (including images, links, and all content) - anything that exceeds that amount will cause an error and prevent the card from sending.
  {% endalert %}
 

--- a/_docs/_developer_guide/platform_integration_guides/web/content_cards/overview.md
+++ b/_docs/_developer_guide/platform_integration_guides/web/content_cards/overview.md
@@ -29,3 +29,8 @@ Content Cards typically sit in a feed of sorts (but not necessarily), and help y
 This is what it looks like for your users to open a basic Content Card feed. As you can see, there are three basic types of cards that can sit in the feed - a Banner Card, a Captioned Content Card, and a Classic Content Card.
 
 ![Content Cards Feed]({% image_buster /assets/img/cc-feed_web.png %}){: height="50%" width="50%"}
+
+ {% alert note %}
+ Content Cards have a maximum size of 2kb (including images, links, and all content) - anything that exceeds that amount will cause an error and prevent the card from sending.
+ {% endalert %}
+


### PR DESCRIPTION
# Pull Request/Issue Resolution
BD-293: updating location of "size limit" note in all content card dev docs. 


**Description of Change:**
> I'm changing..... (could be a link, a new image, a new section, etc.)...


**Reason for Change:**
> I'm making this change because.....


Closes #**ISSUE_NUMBER_HERE**

### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Feature Release Date:__)
- [ ] No

> If yes, please note the date of the feature release.


---
---

## PR Checklist
- [ ] Ensure you have completed [our CLA](https://www.braze.com/docs/cla/).
- [ ] Tag @EmilyNecciai as a reviewer when the your work is _done and ready to be reviewed for merge_.
- [ ] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide).
- [ ] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices).
- [ ] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

## ATTENTION: REVIEWERS OF THIS PR
- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Preview all changes in the linked Heroku environment (click `View deployment` button below, then "Docs". A `502` error just means you should refresh until you see the Docs Home page.
---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
