### PR TITLE
Updated error codes

### DIFF
--- a/_docs/_api/errors.md
+++ b/_docs/_api/errors.md
@@ -70,7 +70,9 @@ The following status codes and associated error messages will be returned if you
 | `400 Invalid Message Variant` | You provided a valid campaign ID, but the message variation ID doesn't match any of that campaign's messages.|
 | `400 Mismatched Message Type` | You provided a message variation of the wrong message type for at least one of your messages.|
 | `400 Invalid Extra Push Payload` | You provide the `extra` key for either `apple_push` or `android_push` but it is not a dictionary.|
-| `400 Max Input Length Exceeded` | Caused by calling more than 50 external ids.|
+| `400 Max Input Length Exceeded` | Caused by calling more than 75 external ids when hitting the User Track endpoint.|
+| `400 The max number of external_ids and aliases per request was exceeded` | Caused by calling more than 50 external ids.|
+| `400 The max number of ids per request was exceeded` | Caused by calling more than 50 external ids.|
 | `400 No message to send` | No payload is specified for the message.|
 | `400 Slideup Message Length Exceeded` | Slideup message contains more than 140 characters.|
 | `400 Apple Push Length Exceeded` | JSON payload is more than 1912 bytes.|


### PR DESCRIPTION
Changed the value from 50 > 75 as the limit of external_ids for the User Track endpoint.
Added an additional error as the other endpoints e.g. "user export" send a slightly different response when more than 50 external_ids are specified.
Added ANOTHER additional error as the other endpoints e.g. "user delete" send ANOTHER slightly different response when more than 50 external_ids are specified.

# Pull Request/Issue Resolution

**Description of Change:**
> I'm changing the Max Input Length Exceeded description since it's out of date and adding two additional errors.


**Reason for Change:**
> I'm making this change because it's unclear as to how many external_ids can be specified when POSTing data to User Track.


Closes #**ISSUE_NUMBER_HERE**

### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Feature Release Date:__)
- [ ] No

> If yes, please note the date of the feature release.


---
---

## PR Checklist
- [ ] Ensure you have completed [our CLA](https://www.braze.com/docs/cla/).
- [ ] Tag @EmilyNecciai as a reviewer when the your work is _done and ready to be reviewed for merge_.
- [ ] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide).
- [ ] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices).
- [ ] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

## ATTENTION: REVIEWERS OF THIS PR
- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Preview all changes in the linked Heroku environment (click `View deployment` button below, then "Docs". A `502` error just means you should refresh until you see the Docs Home page.
---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
