### PR TITLE
Fix links React Native iOS docs

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/react_native/ios/sdk_integration.md
+++ b/_docs/_developer_guide/platform_integration_guides/react_native/ios/sdk_integration.md
@@ -25,7 +25,7 @@ Installing the Braze SDK will provide you with analytics functionality, as well 
 6. Update the 'Header Search Paths' in the AppboyReactBridge Xcode project to reference the headers directory of your installation of the Braze iOS SDK.
 
 ### iOS Completing the Integration
-1.  Complete your [iOS SDK integration]({{ site.baseurl }}/developer_guide/platform_integration_guides/ios/initial_sdk_setup/initial_sdk_setup/).  You must pass your Braze API key to the SDK in `startWithApiKey` in your App delegate's `didFinishLaunchingWithOptions:` method and set up your custom endpoint in your `Info.plist` file.
+1.  Complete your [iOS SDK integration][3].  You must pass your Braze API key to the SDK in `startWithApiKey` in your App delegate's `didFinishLaunchingWithOptions:` method and set up your custom endpoint in your `Info.plist` file.
 2.  When you need to make Braze calls from javascript, use the following declaration to import the javascript module:
 
 ```
@@ -42,3 +42,4 @@ For deep links to work on iOS from a cold start, you will need to add the follow
 
 [1]: {{ site.baseurl }}/developer_guide/platform_integration_guides/ios/initial_sdk_setup/cocoapods/#cocoapods-integration
 [2]: {{ site.baseurl }}/developer_guide/platform_integration_guides/ios/advanced_use_cases/manual_sdk_integration/
+[3]: {{ site.baseurl }}/developer_guide/platform_integration_guides/ios/initial_sdk_setup/

--- a/_docs/_developer_guide/platform_integration_guides/react_native/ios/sdk_integration.md
+++ b/_docs/_developer_guide/platform_integration_guides/react_native/ios/sdk_integration.md
@@ -40,5 +40,5 @@ For deep links to work on iOS from a cold start, you will need to add the follow
 [[AppboyReactUtils sharedInstance] populateInitialUrlFromLaunchOptions:launchOptions];
 ```
 
-[1]: {{ site.baseurl }}/developer_guide/platform_integration_guides/ios/initial_sdk_setup/initial_sdk_setup/#ios--sdk-cocoapod-integration
+[1]: {{ site.baseurl }}/developer_guide/platform_integration_guides/ios/initial_sdk_setup/cocoapods/#cocoapods-integration
 [2]: {{ site.baseurl }}/developer_guide/platform_integration_guides/ios/advanced_use_cases/manual_sdk_integration/


### PR DESCRIPTION
# Pull Request/Issue Resolution

**Description of Change:**
> I'm changing..... (could be a link, a new image, a new section, etc.)...
Updated the broken links on the React Native page


**Reason for Change:**
> I'm making this change because.....


Closes #**ISSUE_NUMBER_HERE**

### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Feature Release Date:__)
- [ ] No

> If yes, please note the date of the feature release.


---
---

## PR Checklist
- [ ] Ensure you have completed [our CLA](https://www.braze.com/docs/cla/).
- [ ] Tag @EmilyNecciai as a reviewer when the your work is _done and ready to be reviewed for merge_.
- [ ] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide).
- [ ] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices).
- [ ] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

## ATTENTION: REVIEWERS OF THIS PR
- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Preview all changes in the linked Heroku environment (click `View deployment` button below, then "Docs". A `502` error just means you should refresh until you see the Docs Home page.
---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
