### PR TITLE
update SEO with noindex and description

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -44,8 +44,8 @@ search_debug: false
 
 # For local testing, set to false to increase build time by not pulling partner api
 # and markdown data. MAKE SURE TO TURN BACK ON PRIOR TO COMMIT.
-partner_api: false
-markdown_api: false
+partner_api: true
+markdown_api: true
 
 # CLA Endpoint
 cla_url: 'https://script.google.com/macros/s/AKfycbyKzEkbL5cZBwCjaYJC2CWXP6aYRroe33W0sL0YIt8DnEDqlzkg/exec'

--- a/_config.yml
+++ b/_config.yml
@@ -44,8 +44,8 @@ search_debug: false
 
 # For local testing, set to false to increase build time by not pulling partner api
 # and markdown data. MAKE SURE TO TURN BACK ON PRIOR TO COMMIT.
-partner_api: true
-markdown_api: true
+partner_api: false
+markdown_api: false
 
 # CLA Endpoint
 cla_url: 'https://script.google.com/macros/s/AKfycbyKzEkbL5cZBwCjaYJC2CWXP6aYRroe33W0sL0YIt8DnEDqlzkg/exec'

--- a/_includes/html_include.html
+++ b/_includes/html_include.html
@@ -6,7 +6,7 @@
    {% noindex {{ page.path }} %}
   <link rel="icon" type="image/x-icon" href="{{site.baseurl}}/assets/favicon.ico" sizes="160x160">
 
-  <meta name="description" content="{% if page.excerpt %}{{ page.description | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ page.id | slice: 1,page.id.size | replace: '/', ' ' | replace: '_', ' ' }} {% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}{% endif %}">
+  <meta name="description" content="{% if page.description %}{{ page.description | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ page.id | slice: 1,page.id.size | replace: '/', ' ' | replace: '_', ' ' }} {% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% endif %}">
   <link rel="canonical" {% if page.url == site.index_url %} href= "{{ site.baseurl | prepend: site.homeurl }}" {% else %} href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.homeurl }}"{% endif %}>
 
   <meta name="keywords" content="braze, docs, documentation, appboy, academy{{ page.id | replace: '_', ' ' | replace: '/', ', ' }} ">

--- a/_includes/html_include.html
+++ b/_includes/html_include.html
@@ -6,7 +6,7 @@
    {% noindex {{ page.path }} %}
   <link rel="icon" type="image/x-icon" href="{{site.baseurl}}/assets/favicon.ico" sizes="160x160">
 
-  <meta name="description" content="{{ page.id | slice: 1,page.id.size | replace: '/', ' ' | replace: '_', ' ' }} {% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
+  <meta name="description" content="{% if page.excerpt %}{{ page.description | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ page.id | slice: 1,page.id.size | replace: '/', ' ' | replace: '_', ' ' }} {% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}{% endif %}">
   <link rel="canonical" {% if page.url == site.index_url %} href= "{{ site.baseurl | prepend: site.homeurl }}" {% else %} href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.homeurl }}"{% endif %}>
 
   <meta name="keywords" content="braze, docs, documentation, appboy, academy{{ page.id | replace: '_', ' ' | replace: '/', ', ' }} ">

--- a/_includes/html_include.html
+++ b/_includes/html_include.html
@@ -6,7 +6,7 @@
    {% noindex {{ page.path }} %}
   <link rel="icon" type="image/x-icon" href="{{site.baseurl}}/assets/favicon.ico" sizes="160x160">
 
-  <meta name="description" content="{% if page.description %}{{ page.description | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ page.id | slice: 1,page.id.size | replace: '/', ' ' | replace: '_', ' ' }} {% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% endif %}">
+  <meta name="description" content="{% if page.description %}{{ page.description | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ page.id | slice: 1,page.id.size | replace: '/', ' ' | replace: '_', ' ' }} {% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% endif %}{% endif %}">
   <link rel="canonical" {% if page.url == site.index_url %} href= "{{ site.baseurl | prepend: site.homeurl }}" {% else %} href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.homeurl }}"{% endif %}>
 
   <meta name="keywords" content="braze, docs, documentation, appboy, academy{{ page.id | replace: '_', ' ' | replace: '/', ', ' }} ">

--- a/_plugins/noindex.rb
+++ b/_plugins/noindex.rb
@@ -15,8 +15,9 @@ module Jekyll
       hiddenpage = Liquid::Template.parse(@hidden).render(context)
       currentpage = context.registers[:page]
       hidepage = currentpage['hidden'].nil? ? false : currentpage['hidden']
+      noindex = currentpage['noindex'].nil? ? false : currentpage['noindex']
 
-      if  (ENV['SITE_URL'].to_s.downcase != 'https://www.braze.com') || (hiddenpage.start_with? '_hidden') || (hidepage)
+      if  (ENV['SITE_URL'].to_s.downcase != 'https://www.braze.com') || (hiddenpage.start_with? '_hidden') || (hidepage) || (noindex)
         "<meta name=\"robots\" content=\"noindex, nofollow\" >"
       else
         "<meta name=\"google-site-verification\" content=\"kI0o3QRqDw5zhtd9W5umZTzLTDe6X1tp-gybtFg_7bQ\" />"


### PR DESCRIPTION
# Pull Request/Issue Resolution
Use `noindex: true` to hide page from SEO and YML description for SEO description.

**Description of Change:**
> I'm changing..... (could be a link, a new image, a new section, etc.)...


**Reason for Change:**
> I'm making this change because.....


Closes #**ISSUE_NUMBER_HERE**

### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Feature Release Date:__)
- [ ] No

> If yes, please note the date of the feature release.


---
---

## PR Checklist
- [ ] Ensure you have completed [our CLA](https://www.braze.com/docs/cla/).
- [ ] Tag @EmilyNecciai as a reviewer when the your work is _done and ready to be reviewed for merge_.
- [ ] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide).
- [ ] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices).
- [ ] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

## ATTENTION: REVIEWERS OF THIS PR
- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Preview all changes in the linked Heroku environment (click `View deployment` button below, then "Docs". A `502` error just means you should refresh until you see the Docs Home page.
---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
