### PR TITLE
BD-335: Adding Steps Between Steps to a Canvas Post Launch Conditions

### DIFF
--- a/_docs/_user_guide/engagement_tools/canvas/create_a_canvas/change_your_canvas_after_launch.md
+++ b/_docs/_user_guide/engagement_tools/canvas/create_a_canvas/change_your_canvas_after_launch.md
@@ -43,3 +43,4 @@ There are a number of things to know if you plan to edit or add more steps to an
 - Users who have not yet entered the Canvas __will__ be eligible for newly created steps.
 - Users who have already passed newly created steps __will__ be eligible next time they re-enter if you have allowed users to re-enter the Canvas in Canvas Entry Settings.
 - Users who are currently in a Canvas, but have not reached the points where new steps are added __will__ be eligible to receive those new steps.
+- You cannot edit or delete existing connections nor can you insert a step between existing connected steps once a Canvas is launched.


### PR DESCRIPTION
BD-335

Added " - You cannot edit or delete existing connections nor can you insert a step between existing connected steps once a Canvas is launched." to page.