### PR TITLE
Removing Edit on Github Button from Vid Template

### DIFF
--- a/_layouts/featured_video.html
+++ b/_layouts/featured_video.html
@@ -73,11 +73,6 @@ layout: default
 
 {%- unless hide_toc -%}
 <div class="d-none d-lg-block col-lg-2 d-print-none featured_toc" id="toc_col">
-  <div class="gitedit_div" style="margin-top: 10px;padding-left: 5px;">
-      <a href="{{site.github_baseurl}}{{page.relative_path }}" class="extignore" target="_blank">
-          <img src="{{site.baseurl}}/assets/img/{{site.github_icon}}" /> &nbsp; Edit this page on GitHub
-      </a>
-  </div>
   <div id="toc" ></div>
 </div>
 {%- endunless -%}


### PR DESCRIPTION
# Pull Request/Issue Resolution

**Description of Change:**
> I'm changing..... (could be a link, a new image, a new section, etc.)...


**Reason for Change:**
> I'm making this change because.....


Closes #**ISSUE_NUMBER_HERE**

### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Feature Release Date:__)
- [ ] No

> If yes, please note the date of the feature release.


---
---

## PR Checklist
- [ ] Ensure you have completed [our CLA](https://www.braze.com/docs/cla/).
- [ ] Tag @EmilyNecciai as a reviewer when the your work is _done and ready to be reviewed for merge_.
- [ ] Consult the [Docs Text Formatting Guide](https://github.com/Appboy/success/wiki/Docs-Text-Formatting-Guide).
- [ ] Consult the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/success/wiki/Writing-Style-Guide-&-Best-Practices).
- [ ] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

## ATTENTION: REVIEWERS OF THIS PR
- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Preview all changes in the linked Heroku environment (click `View deployment` button below, then "Docs". A `502` error just means you should refresh until you see the Docs Home page.
---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @EmilyNecciai. -->
