### PR TITLE
Xamarin Integration Instructions missing Cluster

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/xamarin/android_and_fireos/customer_feedback.md
+++ b/_docs/_developer_guide/platform_integration_guides/xamarin/android_and_fireos/customer_feedback.md
@@ -35,6 +35,7 @@ Now that the libraries have been integrated, you have to create an `Appboy.xml` 
     <?xml version="1.0" encoding="utf-8"?>
     <resources>
     <string name="com_appboy_api_key">REPLACE_WITH_YOUR_API_KEY</string>
+    <string translatable="false" name="com_appboy_custom_endpoint">YOUR_CUSTOM_ENDPOINT_OR_CLUSTER</string>
     </resources>
 ```
 


### PR DESCRIPTION
The Xamarin SDK Integration for Android are missing the Cluster specification within the appboy.xml file. This is causing a default Xamarin integration to point to US-01. These should be updated to match the native Android documentation, which instructs the client to specify their specific Braze Cluster. The native Android documentation I'm referring to is this:
https://www.braze.com/docs/developer_guide/platform_integration_guides/android/initial_sdk_setup/android_sdk_integration/#step-2-configure-the-braze-sdk-in-appboyxml

@KellieHawks 

<details>
<summary>PR Checklist</summary>

- [ X] Check that all links work!
- [X] Ensure you have completed [our CLA](https://www.braze.com/docs/cla/).
- [X] Tag @KellieHawks as a reviewer when your work is _done and ready to be reviewed for merge_.
- [X ] Tag others as Reviewers as necessary.
- [ X] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

</details>
