### PR TITLE
Incremental building of the documentation for debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ _algolia_api_key
 jekyll-algolia-*
 **/.asset_pipeline
 .jekyll-cache
-
+.vscode
+.jekyll-metadata

--- a/Rakefile
+++ b/Rakefile
@@ -27,7 +27,13 @@ namespace :docs do
       puts `bundle exec jekyll build`
   end
   task :serve do
-    pipe 'bundle exec jekyll s --port 5006'
+    if ENV["SITE_URL"] == 'https://www.braze.com' && ENV["RACK_ENV"] == 'production'
+      pipe 'bundle exec jekyll s --port 5006'
+    else
+      # Force a clean build of the site and the pipeline assets
+      puts `rm .jekyll-metadata`
+      pipe 'bundle exec jekyll s --port 5006 --incremental'
+    end
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -27,7 +27,7 @@ namespace :docs do
       puts `bundle exec jekyll build`
   end
   task :serve do
-    if ENV["USE_INCREMENTAL"]
+    if ENV["RACK_ENV"] == 'staging'
       # Force a clean build of the site and the pipeline assets
       puts `rm .jekyll-metadata`
       pipe 'bundle exec jekyll s --port 5006 --incremental --config _config.yml,_incremental_config.yml'

--- a/Rakefile
+++ b/Rakefile
@@ -27,12 +27,12 @@ namespace :docs do
       puts `bundle exec jekyll build`
   end
   task :serve do
-    if ENV["SITE_URL"] == 'https://www.braze.com' && ENV["RACK_ENV"] == 'production'
-      pipe 'bundle exec jekyll s --port 5006'
-    else
+    if ENV["USE_INCREMENTAL"]
       # Force a clean build of the site and the pipeline assets
       puts `rm .jekyll-metadata`
-      pipe 'bundle exec jekyll s --port 5006 --incremental'
+      pipe 'bundle exec jekyll s --port 5006 --incremental --config _config.yml,_incremental_config.yml'
+    else
+      pipe 'bundle exec jekyll s --port 5006'
     end
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -28,11 +28,11 @@ namespace :docs do
   end
   task :serve do
     if ENV["RACK_ENV"] == 'staging'
+      pipe 'bundle exec jekyll s --port 5006'
+    else
       # Force a clean build of the site and the pipeline assets
       puts `rm .jekyll-metadata`
       pipe 'bundle exec jekyll s --port 5006 --incremental --config _config.yml,_incremental_config.yml'
-    else
-      pipe 'bundle exec jekyll s --port 5006'
     end
   end
 end

--- a/_config.yml
+++ b/_config.yml
@@ -191,7 +191,6 @@ asset_pipeline:
   output_path: assets
   display_path: docs/assets
   gzip: false
-  staging_path: '../.documentation_asset_pipeline'
 
 # Algolia Search index
 algolia:

--- a/_config.yml
+++ b/_config.yml
@@ -191,6 +191,7 @@ asset_pipeline:
   output_path: assets
   display_path: docs/assets
   gzip: false
+  staging_path: '../.documentation_asset_pipeline'
 
 # Algolia Search index
 algolia:

--- a/_incremental_config.yml
+++ b/_incremental_config.yml
@@ -1,0 +1,3 @@
+# Image asset pipeline setting for japr
+asset_pipeline:
+  staging_path: '../.documentation_asset_pipeline'

--- a/_plugins/jekyll_asset_pipeline.rb
+++ b/_plugins/jekyll_asset_pipeline.rb
@@ -13,6 +13,7 @@ module JekyllAssetPipeline
       return Sass::Engine.new(@content, syntax: :scss, load_paths: [@dirname]).render
     end
   end
+
   class CssCompressor < JekyllAssetPipeline::Compressor
     require 'yui/compressor'
 

--- a/assets/css/_404.scss
+++ b/assets/css/_404.scss
@@ -12,7 +12,6 @@ $broken_transition_time : 0.25s;
     margin-right: auto;
   }
 
-
   h1 {
     color: $black-shark;
     font-family: $braze-medium;


### PR DESCRIPTION
**Why**
Local builds that used to take 60 seconds now take 4.

**Description of Change:**
Introduced incremental builds

The reason that https://github.com/Appboy/braze-docs/pull/605/files didn't work was because the `_config.yml` listed the documentation source directory as `.`, meaning that all files, including build temporary files, were treated as source by default and visible to the file watcher.

Thus, when the asset pipeline generated its css, js, etc. files, the file change watcher would pick them up as source changes, "regenerate" them and thus delete them. The end result was that those asset files would get deleted and break all the documentation pages. 

The _incremental_ fix in this PR was to move the asset pipeline folder out of the source tree. Since all files in this repo are technically source files, that meant moving the folder to whatever parent directory exists above where the documentation repo exists on the local machine.

The true proper fix would be to have all of the actual source files (like markdown pages, assets, includes, etc.), live in a `./src` folder and all of the files that are used to build the documentation be at root level.
