### PR TITLE
Added data type coercion table

### DIFF
--- a/_docs/_user_guide/administrative/app_settings/manage_app_group/custom_event_and_attribute_management.md
+++ b/_docs/_user_guide/administrative/app_settings/manage_app_group/custom_event_and_attribute_management.md
@@ -56,8 +56,7 @@ If you elect to force the data type for an attribute, any data that comes in tha
 | Boolean | Inputs of `0`, `false`, `f` (not case sensitive) will be stored as `false` |
 | Number | Integers or Floats (i.e. `1`, `1.5`) will be stored as numbers |
 | Array | Comma separated list of values, with or without square brackets (i.e.`[first, second, third]`, or `first,second,third`) will be stored as an Array |
-
-
+{: .reset-td-br-1 .reset-td-br-2}
 
 For more information on specific filter options exposed by different data type comparisons please see ["Configuring Reporting - Braze Academy"][43]. And for more information on the different available data types, please see the section on ["Custom Attribute Data Types"][44].
 

--- a/_docs/_user_guide/administrative/app_settings/manage_app_group/custom_event_and_attribute_management.md
+++ b/_docs/_user_guide/administrative/app_settings/manage_app_group/custom_event_and_attribute_management.md
@@ -44,7 +44,20 @@ Braze automatically recognizes data types for attribute data that is sent to us.
 
 ![customeventsviewdatatypedropdown1.png][75]
 
+{% alert warning %}
 If you elect to force the data type for an attribute, any data that comes in that isn't the specified type will be ignored.
+{% endalert %}
+
+### Data Type Coercion
+
+| Forced Data Type | Description |
+|------------------|-------------|
+| Boolean | Inputs of `1`, `true`, `t` (not case sensitive) will be stored as `true` |
+| Boolean | Inputs of `0`, `false`, `f` (not case sensitive) will be stored as `false` |
+| Number | Integers or Floats (i.e. `1`, `1.5`) will be stored as numbers |
+| Array | Comma separated list of values, with or without square brackets (i.e.`[first, second, third]`, or `first,second,third`) will be stored as an Array |
+
+
 
 For more information on specific filter options exposed by different data type comparisons please see ["Configuring Reporting - Braze Academy"][43]. And for more information on the different available data types, please see the section on ["Custom Attribute Data Types"][44].
 

--- a/_docs/_user_guide/administrative/app_settings/manage_app_group/custom_event_and_attribute_management.md
+++ b/_docs/_user_guide/administrative/app_settings/manage_app_group/custom_event_and_attribute_management.md
@@ -42,6 +42,8 @@ Please note that you should still remove the event/attribute from your app code 
 ## Forcing Data Type Comparisons
 Braze automatically recognizes data types for attribute data that is sent to us. However, in the event multiple data types are applied to a single attribute, you can force the data type of any attribute to let us know what it really is. Click on the drop-down in the Data Type column to choose.
 
+*Note*: Forcing data types does not apply to event properties, or purchase properties.
+
 ![customeventsviewdatatypedropdown1.png][75]
 
 {% alert warning %}


### PR DESCRIPTION
Added a table to describe how forced data type coercion behaves, specifically that you can pass in arrays as comma separated values, or `t`|`1` for booleans

![image](https://user-images.githubusercontent.com/7410770/86400304-5f583300-bc76-11ea-9ed6-a1b25923cf48.png)
