### PR TITLE
BD-641: Remove/Update iOS/IDFA Docs

### DIFF
--- a/_docs/_partners/advertising_technologies/attribution/adjust.md
+++ b/_docs/_partners/advertising_technologies/attribution/adjust.md
@@ -34,15 +34,10 @@ Adjust.addSessionPartnerParameter("braze_device_id", Appboy.getInstance(getAppli
 {% endtab %}
 {% tab iOS %}
 
-If you have and iOS app, you will need to include the code snippet below, which passes the customer's IDFV to Adjust. This ID will then be mapped to a unique device ID in Braze.
+If you have an iOS app, your IDFV will be collected by Adjust and sent to Braze. This ID will then be mapped to a unique device ID in Braze.
 
-```
-Code snippet TBA
-```
+Braze will still store IDFA values for users that have opted-in if you are collecting the IDFA with Braze, as described in our [iOS 14 Upgrade Guide]({{site.baseurl}}/developer_guide/platform_integration_guides/ios/ios_14/#idfa). Otherwise, the IDFV will be used as a fallback identifier to map users.
 
-{% alert important %}
-As of MM/DD/YYYY, we're recommending that all customers use the Braze `device_id` instead of the IDFA. This is in response to Apple's changes to the [IDFA]({{site.baseurl}}/developer_guide/platform_integration_guides/ios/ios_14/#idfa) as part of the iOS 14 update.
-{% endalert %}
 {% endtab %}
 {% endtabs %}
 
@@ -80,3 +75,24 @@ Assuming you configure your integration as suggested above, Braze will map Adjus
 ## Facebook and Twitter Attribution Data
 
 Attribution data for Facebook and Twitter campaigns is __not available through our partners__. Facebook and Twitter do not permit their partners to share attribution data with third parties and, therefore, our partners __cannot send that data to Braze__.
+
+## Email Deep-Linking and Click Tracking
+
+Using click tracking links in your Braze campaigns will allow you to easily see which campaigns are driving app installs and re-engagement. As a result, you'll be able to measure your marketing efforts more effectively and make data-driven decisions on where to invest more resources for the maximum ROI.
+
+If you are using Adjust click tracking URL in your campaigns, Braze recommends that you include `device_id` as a parameter in the tracking link. The value for this parameter should be the IDFV. Adjust already collects the IDFV through their native integration.
+You can add the IDFV to your click tracking URL by utilizing one of the following Liquid tags: 
+
+{% raw %}
+`{{most_recently_used_device.${id}}}` 
+or 
+`{{targeted_device.${id}}}`
+{% endraw %}
+
+This recommendation is purely optional. If you currently do not use any device identifiers or do not plan to in the future, including IDFV, in your attribution click tracking URLs, [Adjust](https://www.adjust.com/product-updates/adjusts-new-ios-sdk-for-ios-14/) is still able to attribute these clicks through their probabilistic attribution modeling. 
+
+However, by adding the IDFV to your tracking links, you will be able to track attributions deterministically and with greater accuracy. 
+
+{% alert important %}
+Note: Adding the `device_id` parameter to your click tracking links is optional. Your campaigns will continue to be tracked even if you choose not to update your links to include it.
+{% endalert %}

--- a/_docs/_partners/advertising_technologies/attribution/adjust.md
+++ b/_docs/_partners/advertising_technologies/attribution/adjust.md
@@ -21,14 +21,30 @@ This integration supports iOS and Android apps.
 | Braze SDK | Be sure to enable the proper SDK for your needs - either [Android]({{site.baseurl}}/developer_guide/platform_integration_guides/android/initial_sdk_setup/android_sdk_integration/) or [iOS]({{site.baseurl}}/developer_guide/platform_integration_guides/ios/initial_sdk_setup/).|
 | Braze API Key & REST Endpoint | In your Braze account, navigate to Technology Partners and search for Adjust. There, you'll find the Install API Key and the REST Endpoint. The Install API Key and REST Endpoint will be used to set up a postback in Adjust’s dashboard. |
 | Adjust SDK | Please see the [Adjust docs](https://docs.adjust.com/en/getting-started/#integrate-the-adjust-sdk) for more information on this requirement. |
-| Enable IDFA Collection in Braze SDK | [IDFA Collection]({{site.baseurl}}/developer_guide/platform_integration_guides/ios/initial_sdk_setup/optional_idfa_collection/#optional-idfa-collection) is optional within the Braze SDK and disabled by default. This is required to be enabled for all of our Attribution partner integrations. |
 {: .reset-td-br-1 .reset-td-br-2}
+
+{% tabs %}
+{% tab Android %}
 
 If you have an Android app, you will need to include the code snippet below, which passes a unique Braze device ID to Adjust. You should call the following before initializing the SDK on `Adjust.onCreate.`:
 
 ```
 Adjust.addSessionPartnerParameter("braze_device_id", Appboy.getInstance(getApplicationContext()).getDeviceId()););
 ```
+{% endtab %}
+{% tab iOS %}
+
+If you have and iOS app, you will need to include the code snippet below, which passes the customer's IDFV to Adjust. This ID will then be mapped to a unique device ID in Braze.
+
+```
+Code snippet TBA
+```
+
+{% alert important %}
+As of MM/DD/YYYY, we're recommending that all customers use the Braze `device_id` instead of the IDFA. This is in response to Apple's changes to the [IDFA]({{site.baseurl}}/developer_guide/platform_integration_guides/ios/ios_14/#idfa) as part of the iOS 14 update.
+{% endalert %}
+{% endtab %}
+{% endtabs %}
 
 {% alert note %}
 If you are planning to send post-install events from Adjust into Braze, you will need to ensure that you append `external_id` as a session and event parameter within the Adjust SDK. For revenue event forwarding, you will need to set up `product_id` as a parameter for events. For more information on defining partner parameters for event forwarding see [Adjust’s documentation](https://github.com/adjust/sdks).
@@ -41,11 +57,9 @@ To integrate Braze with Adjust, you must configure Braze in Adjust's dashboard.
 1. In Adjust’s dashboard, navigate to __App Settings__ and navigate to __Partner Setup__, then __Add Partners__.
 2. Select __Braze (formerly Appboy)__.
 3. Copy the Braze API Key into the `Install API Key` field.
-- This Braze API Key is available in the Braze Dashboard. This can be found by navigating to __Technology Partners__ under __Integrations__ and selecting __Adjust__. From here, the API you need is housed under the __Data Import for Install Attribution__ section.
+	* This Braze API Key is available in the Braze Dashboard. This can be found by navigating to __Technology Partners__ under __Integrations__ and selecting __Adjust__. From here, the API you need is housed under the __Data Import for Install Attribution__ section.
 4. Copy the Braze REST Endpoint into the `REST_endpoint` field.
 5. Click __Save & Close__.
-
-
 
 ### Attribution Parameters
 

--- a/_docs/_partners/advertising_technologies/attribution/appsflyer.md
+++ b/_docs/_partners/advertising_technologies/attribution/appsflyer.md
@@ -40,7 +40,15 @@ AppsFlyerLib.setAdditionalData(customData);
 {% endtab %}
 {% tab iOS %}
 
-If you have an iOS app, the Braze SDK requires that you have [IDFA collection]({{site.baseurl}}/developer_guide/platform_integration_guides/ios/initial_sdk_setup/optional_idfa_collection/#optional-idfa-collection) enabled. 
+If you have an iOS app, you will need to include the code snippet below, which passes the customer's IDFV to AppsFlyer. This ID will then be mapped to a unique device ID in Braze.
+
+```
+Code Snippet TBA
+```
+
+{% alert important %}
+As of MM/DD/YYYY, we're recommending that all customers use the Braze `device_id` instead of the IDFA. This is in response to Apple's changes to the [IDFA]({{site.baseurl}}/developer_guide/platform_integration_guides/ios/ios_14/#idfa) as part of the iOS 14 update.
+{% endalert %}
 
 {% endtab %}
 {% tab Unity %}

--- a/_docs/_partners/advertising_technologies/attribution/appsflyer.md
+++ b/_docs/_partners/advertising_technologies/attribution/appsflyer.md
@@ -40,15 +40,9 @@ AppsFlyerLib.setAdditionalData(customData);
 {% endtab %}
 {% tab iOS %}
 
-If you have an iOS app, you will need to include the code snippet below, which passes the customer's IDFV to AppsFlyer. This ID will then be mapped to a unique device ID in Braze.
+If you have an iOS app, your IDFV will be collected by AppsFlyer and sent to Braze. This ID will then be mapped to a unique device ID in Braze.
 
-```
-Code Snippet TBA
-```
-
-{% alert important %}
-As of MM/DD/YYYY, we're recommending that all customers use the Braze `device_id` instead of the IDFA. This is in response to Apple's changes to the [IDFA]({{site.baseurl}}/developer_guide/platform_integration_guides/ios/ios_14/#idfa) as part of the iOS 14 update.
-{% endalert %}
+Braze will still store IDFA values for users that have opted-in if you are collecting the IDFA with Braze, as described in our [iOS 14 Upgrade Guide]({{site.baseurl}}/developer_guide/platform_integration_guides/ios/ios_14/#idfa). Otherwise, the IDFV will be used as a fallback identifier to map users.
 
 {% endtab %}
 {% tab Unity %}
@@ -107,7 +101,23 @@ For more information, please see AppsFlyer's [documentation][31].
 
 Deep links, links that direct users toward a specific page or place within an app or website, are crucial in creating a tailored user experience. While widely used, often issues come up when using them in tandem with click tracking, another vital feature used in collecting user data. These issues are due to ESPs (Email Service Providers) wrapping deep links in their own click recording domain, breaking the original link. 
 
-There are, however, ESPs like Sendgrid that support both universal linking and click tracking. Braze recommends integrating OneLink-based attribution links into your SendGrid email system in order to seamlessly deep link from emails. <br>To get started, check out AppsFlyer's [documentation][3].
+There are, however, ESPs like Sendgrid that support both universal linking and click tracking. Braze recommends integrating OneLink-based attribution links into your SendGrid email system in order to seamlessly deep link from emails. To get started, check out AppsFlyer's [documentation][3].
+
+If you are using an AppsFlyer click tracking URL in your campaigns, Braze recommends that you include `device_id` as a parameter in the tracking link. The value for this parameter should be the IDFV. AppsFlyer already collects the IDFV through their native integration.
+You can add the IDFV to your click tracking URL by utilizing one of the following Liquid tags:
+
+{% raw %}
+`{{most_recently_used_device.${id}}}` 
+or 
+`{{targeted_device.${id}}}`
+{% endraw %}
+
+This recommendation is purely optional. If you currently do not use any device identifiers or do not plan to in the future, including IDFV, in your attribution click tracking URLs, [AppsFlyer](https://support.appsflyer.com/hc/en-us/articles/360011420698-AppsFlyer-SKAdNetwork-Solution-iOS-14-attribution-without-IDFA) is still able to attribute these clicks through their probabilistic attribution [modeling](https://support.appsflyer.com/hc/en-us/articles/207447053-Attribution-model-explained#:~:text=The%20Attribution%20Model%20is%20a,to%20touchpoints%20in%20conversion%20paths.&text=Most%20important%20is%20to%20understand,and%20launches%20the%20mobile%20app.). 
+However, by adding the IDFV to your tracking links, you will be able to track attributions deterministically and with greater accuracy. 
+
+{% alert important %}
+Note: Adding the `device_id` parameter to your click tracking links is optional. Your campaigns will continue to be tracked even if you choose not to update your links to include it.
+{% endalert %}
 
 [1]: {% image_buster /assets/img/braze_integration.png %}
 [2]: {% image_buster /assets/img/braze_attribution.png %}

--- a/_docs/_partners/advertising_technologies/attribution/branch_for_attribution.md
+++ b/_docs/_partners/advertising_technologies/attribution/branch_for_attribution.md
@@ -35,15 +35,10 @@ Branch.initSession(...);
 ```
 {% endtab %}
 {% tab iOS %}
-If you have an iOS app, you will need to include the code snippet below, which passes the customer's IDFV to Branch. This ID will then be mapped to a unique device ID in Braze.
 
-```
-Code Snippet TBA
-```
+If you have an iOS app, your IDFV will be collected by Branch and sent to Braze. This ID will then be mapped to a unique device ID in Braze.
 
-{% alert important %}
-As of MM/DD/YYYY, we're recommending that all customers use the Braze `device_id` instead of the IDFA. This is in response to Apple's changes to the [IDFA]({{site.baseurl}}/developer_guide/platform_integration_guides/ios/ios_14/#idfa) as part of the iOS 14 update.
-{% endalert %}
+Braze will still store IDFA values for users that have opted-in if you are collecting the IDFA with Braze, as described in our [iOS 14 Upgrade Guide]({{site.baseurl}}/developer_guide/platform_integration_guides/ios/ios_14/#idfa). Otherwise, the IDFV will be used as a fallback identifier to map users.
 
 {% endtab %}
 {% endtabs %}
@@ -63,6 +58,26 @@ Once Braze receives attribution data from Branch, the status connection indicato
 ## Facebook and Twitter Attribution Data
 
 Attribution data for Facebook and Twitter campaigns is __not available through our partners__. These media sources do not permit their partners to share attribution data with third parties and, therefore, our partners __cannot send that data to Braze__.
+
+## Email Deep-Linking and Click Tracking
+
+Using click tracking links in your Braze campaigns will allow you to easily see which campaigns are driving app installs and re-engagement. As a result, you'll be able to measure your marketing efforts more effectively and make data-driven decisions on where to invest more resources for the maximum ROI. 
+
+If you are using an attribution partner click tracking URL in your campaigns, Braze recommends that you include `device_id` as a parameter in the tracking link. The value for this parameter should be the IDFV. Branch already collects the IDFV through their native integration.
+You can add the IDFV to your click tracking URL by utilizing one of the following Liquid tags:
+
+{% raw %}
+`{{most_recently_used_device.${id}}}` 
+or 
+`{{targeted_device.${id}}}`
+{% endraw %}
+
+This recommendation is purely optional. If you currently do not use any device identifiers or do not plan to in the future, including IDFV, in your attribution click tracking URLs, [Branch](https://branch.io/ios-14/) is still able to attribute these clicks through their probabilistic attribution modeling. 
+However, by adding the IDFV to your tracking links, you will be able to track attributions deterministically and with greater accuracy.
+
+{% alert important %} 
+Note: Adding the `device_id` parameter to your click tracking links is optional. Your campaigns will continue to be tracked even if you choose not to update your links to include it.
+{% endalert %}
 
 [5]: {{site.baseurl}}/developer_guide/rest_api/basics/#api-limits
 [13]: {{site.baseurl}}/developer_guide/platform_integration_guides/ios/initial_sdk_setup/optional_idfa_collection/#optional-idfa-collection "IDFA Collection"

--- a/_docs/_partners/advertising_technologies/attribution/branch_for_attribution.md
+++ b/_docs/_partners/advertising_technologies/attribution/branch_for_attribution.md
@@ -11,7 +11,7 @@ page_type: partner
 
 {% include video.html id="PwGKqfwV-Ss" align="right" %}
 
-> [Branch](https://docs.branch.io/pages/integrations/braze/), a mobile linking platform, helps you acquire, engage, and measure across all devices, channels, and platforms by providing a holistic view of all user touch points. This article will walk you through how to use Branch with Braze to support your attribution needs.
+> [Branch](https://docs.branch.io/pages/integrations/braze/), a mobile linking platform, helps you acquire, engage, and measure across all devices, channels, and platforms by providing a holistic view of all user touchpoints. This article will walk you through how to use Branch with Braze to support your attribution needs.
 
 Branch and Braze help you understand exactly when and where users were acquired as well as how to personalize their journeys through robust attribution and [deep linking]({{site.baseurl}}/partners/channel_extensions/deep_linking/branch_for_deeplinking/).
 
@@ -21,7 +21,9 @@ Branch and Braze help you understand exactly when and where users were acquired 
 
 * This integration supports iOS and Android.
 * Your app will need Braze's SDK and Branch's SDK installed.
-* You will need to [enable IDFA collection][13] in Braze's SDK.
+
+{% tabs %}
+{% tab Android %}
 * If you have an Android app, you will need to include the code snippet below, which passes a unique Braze device id to Branch. You must set the correct key before calling `initSession`. You must also initialize the Braze SDK before setting the request metadata in the Branch SDK.
 
 ```java
@@ -31,6 +33,20 @@ Branch.getInstance().setRequestMetadata("$braze_install_id", Appboy.getInstance(
 
 Branch.initSession(...);
 ```
+{% endtab %}
+{% tab iOS %}
+If you have an iOS app, you will need to include the code snippet below, which passes the customer's IDFV to Branch. This ID will then be mapped to a unique device ID in Braze.
+
+```
+Code Snippet TBA
+```
+
+{% alert important %}
+As of MM/DD/YYYY, we're recommending that all customers use the Braze `device_id` instead of the IDFA. This is in response to Apple's changes to the [IDFA]({{site.baseurl}}/developer_guide/platform_integration_guides/ios/ios_14/#idfa) as part of the iOS 14 update.
+{% endalert %}
+
+{% endtab %}
+{% endtabs %}
 
 ### Step 2: Getting the Attribution ID
 

--- a/_docs/_partners/advertising_technologies/attribution/kochava.md
+++ b/_docs/_partners/advertising_technologies/attribution/kochava.md
@@ -15,36 +15,46 @@ Kochava and Braze power a more holistic understanding of campaigns. Kochava send
 
 ## Integration
 
-__Step 1: Integration Requirements__
+### Step 1: Integration Requirements
 
 * This integration supports iOS, Android, and Windows apps.
 * Your app will need Braze's SDK and Kochava's SDK installed.
-* You will need to [enable IDFA collection][13] in Braze's SDK.
 
-__Step 2: Getting the Attribution ID__
+### Step 2: Getting the Attribution ID
 
 Go to your Braze account, navigate to "Technology Partners", then "Attribution" and find the API key and REST Endpoint in the Kochava section. The API key and the REST Endpoint are used in the next step when setting up a postback in Kochava's dashboard.
 
-__Step 3: Setting Up A Postback from Kochava__
+### Step 3: Setting Up A Postback from Kochava
 
 Follow [these instructions][18] to add a postback in Kochava's dashboard. You will be prompted for the key and REST Endpoint that you found in Braze's Dashboard in Step 2. Select the __"POST"__ request when creating the PostBack Call on Kochava's dashboard.
 
-__Step 4: Confirming the Integration__
+### Step 4: Confirming the Integration
 
 Once Braze receives attribution data from Kochava, the status connection indicator on "Technology Partners", then "Attribution" will change to green and a timestamp of the last successful request will be included. Note that this will not happen until we receive data about an __attributed__ install. Organic installs are ignored by our API and are not counted when determining if a successful connection was established.
-
+<br><br>
 __Note for [Android][29] and [Windows][30] Support__:<br>
 If you are planning to leverage the server-side integration between Braze and Kochava, you will need to ensure that you utilize the `IdentityLink` method of the Kochava SDK to capture the Braze ID. The 'Braze ID' can be retrieved using the following method:
 
 {% tabs %}
 {% tab JAVA %}
+The [Android](https://support.kochava.com/sdk-integration/sdk-kochavatracker-android/class-tracker?scrollto=marker_3) SDK generates a GUID as the Braze ID on session start. This is the identifier we recommend using to pass into the Kochava `IdentityLink` method as it allows Braze to reconcile the data back to the correct user profile. Please ensure that you instrument this method to pass the 'Braze ID' on SDK initialization to ensure it is available when Kochava is posting your data back to Braze via the server-side integration.
+
 ```java
 Apppboy.getInstance(context).getDeviceId();
 ```
 {% endtab %}
-{% endtabs %}
+{% tab iOS %}
+If you have an iOS app, you will need to include the code snippet below, which passes the customer's IDFV to Adjust. This ID will then be mapped to a unique device ID in Braze.
 
-The [Android][29] SDK generates a GUID as the Braze ID on session start. This is the identifier we recommend using to pass into the Kochava `IdentityLink` method as it allows Braze to reconcile the data back to the correct user profile. Braze also has the option to match on __device_id__ and __IDFA__ (if enabled). Please ensure that you instrument this method to pass the 'Braze ID' on SDK initialization to ensure it is available when Kochava is posting your data back to Braze via the server-side integration.
+```
+Code Snippet TBA
+```
+
+{% alert important %}
+As of MM/DD/YYYY, we're recommending that all customers use the Braze `device_id` instead of the IDFA. This is in response to Apple's changes to the [IDFA]({{site.baseurl}}/developer_guide/platform_integration_guides/ios/ios_14/#idfa) as part of the iOS 14 update.
+{% endalert%}
+{% endtab %}
+{% endtabs %}
 
 ## Facebook and Twitter Attribution Data
 

--- a/_docs/_partners/advertising_technologies/attribution/kochava.md
+++ b/_docs/_partners/advertising_technologies/attribution/kochava.md
@@ -44,15 +44,11 @@ Apppboy.getInstance(context).getDeviceId();
 ```
 {% endtab %}
 {% tab iOS %}
-If you have an iOS app, you will need to include the code snippet below, which passes the customer's IDFV to Adjust. This ID will then be mapped to a unique device ID in Braze.
 
-```
-Code Snippet TBA
-```
+If you have an iOS app, your IDFV will be collected by Kochava and sent to Braze. This ID will then be mapped to a unique device ID in Braze.
 
-{% alert important %}
-As of MM/DD/YYYY, we're recommending that all customers use the Braze `device_id` instead of the IDFA. This is in response to Apple's changes to the [IDFA]({{site.baseurl}}/developer_guide/platform_integration_guides/ios/ios_14/#idfa) as part of the iOS 14 update.
-{% endalert%}
+Braze will still store IDFA values for users that have opted-in if you are collecting the IDFA with Braze, as described in our [iOS 14 Upgrade Guide]({{site.bnaseurl}}/developer_guide/platform_integration_guides/ios/ios_14/#idfa). Otherwise, the IDFV will be used as a fallback identifier to map users.
+
 {% endtab %}
 {% endtabs %}
 
@@ -60,6 +56,23 @@ As of MM/DD/YYYY, we're recommending that all customers use the Braze `device_id
 
 Attribution data for Facebook and Twitter campaigns is __not available through our partners__. These media sources do not permit their partners to share attribution data with third parties and, therefore, our partners __cannot send that data to Braze__.
 
+## Email Deep-Linking and Click Tracking
+
+If you are using an attribution partner click tracking URL in your campaigns, Braze recommends that you include `device_id` as a parameter in the tracking link. The value for this parameter should be the IDFV. Kochava already collects the IDFV through their native integration.
+You can add the IDFV to your click tracking URL by utilizing one of the following Liquid tags:
+
+{% raw %}
+`{{most_recently_used_device.${id}}}` 
+or 
+`{{targeted_device.${id}}}`
+{% endraw %}
+
+This recommendation is purely optional. If you currently do not use any device identifiers or do not plan to in the future, including IDFV, in your attribution click tracking URLs, [Kochava](https://www.kochava.com/solving-for-attribution-on-ios-14-with-kochava/) is still able to attribute these clicks through their probabilistic attribution modeling.
+However, by adding the IDFV to your tracking links, you will be able to track attributions deterministically and with greater accuracy. 
+
+{% alert important %}
+Note: Adding the `device_id` parameter to your click tracking links is optional. Your campaigns will continue to be tracked even if you choose not to update your links to include it.
+{% endalert %}
 
 [5]: #api-restrictions
 [13]: {{site.baseurl}}/developer_guide/platform_integration_guides/ios/initial_sdk_setup/#optional-idfa-collection

--- a/_docs/_partners/advertising_technologies/attribution/singular.md
+++ b/_docs/_partners/advertising_technologies/attribution/singular.md
@@ -38,15 +38,11 @@ protected void onCreate(Bundle savedInstanceState)
 ```
 {% endtab %}
 {% tab iOS %}
-If you have an iOS app, you will need to include the code snippet below, which passes the customer's IDFV to Singular. This ID will then be mapped to a unique device ID in Braze.
 
-```
-Code Snippet TBA
-```
+If you have an iOS app, your IDFV will be collected by Singular and sent to Braze. This ID will then be mapped to a unique device ID in Braze.
 
-{% alert important %}
-As of MM/DD/YYYY, we're recommending that all customers use the Braze `device_id` instead of the IDFA. This is in response to Apple's changes to the [IDFA]({{site.baseurl}}/developer_guide/platform_integration_guides/ios/ios_14/#idfa) as part of the iOS 14 update.
-{% endalert %}
+Braze will still store IDFA values for users that have opted-in if you are collecting the IDFA with Braze, as described in our [iOS 14 Upgrade Guide]({{site.baseurl}}/developer_guide/platform_integration_guides/ios/ios_14/#idfa). Otherwise, the IDFV will be used as a fallback identifier to map users.
+
 {% endtab %}
 {% endtabs %}
 
@@ -61,6 +57,24 @@ Once Braze receives attribution data from Singular, the status connection indica
 ## Facebook and Twitter Attribution Data
 
 Attribution data for Facebook and Twitter campaigns is __not available through our partners__. These media sources do not permit their partners to share attribution data with third parties and, therefore, our partners __cannot send that data to Braze__.
+
+## Email Deep-Linking and Click Tracking
+
+If you are using an attribution partner click tracking URL in your campaigns, Braze recommends that you include `device_id` as a parameter in the tracking link. The value for this parameter should be the IDFV. Singular already collects the IDFV through their native integration.
+You can add the IDFV to your click tracking URL by utilizing one of the following Liquid tags:
+
+{% raw %}
+`{{most_recently_used_device.${id}}}` 
+or 
+`{{targeted_device.${id}}}`
+{% endraw %}
+
+This recommendation is purely optional. If you currently do not use any device identifiers or do not plan to in the future, including IDFV, in your attribution click tracking URLs, [Singular](https://support.singular.net/hc/en-us/articles/360047706852--New-Preparing-for-iOS-14-FAQ-for-Partners) is still able to attribute these clicks through their probabilistic attribution modeling.
+However, by adding the IDFV to your tracking links, you will be able to track attributions deterministically and with greater accuracy. 
+
+{% alert important %}
+Note: Adding the `device_id` parameter to your click tracking links is optional. Your campaigns will continue to be tracked even if you choose not to update your links to include it.
+{% endalert %}
 
 [5]: #api-restrictions
 [13]: {{site.baseurl}}/developer_guide/platform_integration_guides/ios/initial_sdk_setup/#optional-idfa-collection

--- a/_docs/_partners/advertising_technologies/attribution/singular.md
+++ b/_docs/_partners/advertising_technologies/attribution/singular.md
@@ -19,8 +19,10 @@ Singular allows you to import paid install attribution data to segment more inte
 
 * This integration supports iOS and Android apps.
 * Your app will need Braze's SDK and Singular's SDK installed.
-* If you have an iOS app, you will need to [enable IDFA collection][13] in Braze's SDK.
-* If you have an Android app, you will need to include the code snippet below, which passes a unique Braze user id to Singular. For most setups, 2 lines of code must be added in an app's `onCreate()` method immediately after Singular's `init` method or session start. Braze's `device_id` must be available when the first “App Open” event is sent to Singular.
+
+{% tabs %}
+{% tab Android %}
+If you have an Android app, you will need to include the code snippet below, which passes a unique Braze user id to Singular. For most setups, 2 lines of code must be added in an app's `onCreate()` method immediately after Singular's `init` method or session start. Braze's `device_id` must be available when the first “App Open” event is sent to Singular.
 
 ```java
 @Override
@@ -34,6 +36,19 @@ protected void onCreate(Bundle savedInstanceState)
    Singular.event("App Open", "appboyUserID", appboyDeviceId);
 }
 ```
+{% endtab %}
+{% tab iOS %}
+If you have an iOS app, you will need to include the code snippet below, which passes the customer's IDFV to Singular. This ID will then be mapped to a unique device ID in Braze.
+
+```
+Code Snippet TBA
+```
+
+{% alert important %}
+As of MM/DD/YYYY, we're recommending that all customers use the Braze `device_id` instead of the IDFA. This is in response to Apple's changes to the [IDFA]({{site.baseurl}}/developer_guide/platform_integration_guides/ios/ios_14/#idfa) as part of the iOS 14 update.
+{% endalert %}
+{% endtab %}
+{% endtabs %}
 
 ### Step 2: Getting the Braze API Key
 
@@ -45,8 +60,7 @@ Once Braze receives attribution data from Singular, the status connection indica
 
 ## Facebook and Twitter Attribution Data
 
-Attribution data for Facebook and Twitter campaigns is __not available through our partners__. These media sources do not permit their partners to share attribution data with third-parties and, therefore, our partners __cannot send that data to Braze__.
-
+Attribution data for Facebook and Twitter campaigns is __not available through our partners__. These media sources do not permit their partners to share attribution data with third parties and, therefore, our partners __cannot send that data to Braze__.
 
 [5]: #api-restrictions
 [13]: {{site.baseurl}}/developer_guide/platform_integration_guides/ios/initial_sdk_setup/#optional-idfa-collection


### PR DESCRIPTION
BD-641: Remove/Update iOS/IDFA Docs

- Remove all instances of iOS IDFA
- Link out to iOS 14 upgrade guide
- provide additional blurbs about deeplinking/click tracking settings. 