### PR TITLE
doc: fix platform typo in bitcode section

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/cocoapods.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/cocoapods.md
@@ -139,7 +139,7 @@ See the {% if include.platform == 'iOS' %}
 
 ## SDK Integration Complete
 
-Braze should now be collecting data from your application and your basic integration should be complete. {% if include.platform == 'iOS' %}Please see the following sections in order to enable custom event tracking, push messaging, the news-feed and the complete suite of Braze features.{% else %}Please note that when compiling your tvOS app and any other third-party libraries, Bitcode must be enabled.{% endif %}
+Braze should now be collecting data from your application and your basic integration should be complete. {% if include.platform == 'iOS' %}Please see the following sections in order to enable custom event tracking, push messaging, the news-feed and the complete suite of Braze features.{% else %}Please note that when compiling your iOS app and any other third-party libraries, Bitcode must be enabled.{% endif %}
 
 ## Updating the Braze SDK via CocoaPods
 


### PR DESCRIPTION
# Pull Request/Issue Resolution
Fix probable typo, because mentioning tvOS apps on the iOS integration page seems wrong.

<details>
<summary>PR Checklist</summary>

- [x] Check that all links work!
- [x] Ensure you have completed [our CLA](https://www.braze.com/docs/cla/).
- [x] Tag @Timothy-Kim and @KellieHawks as a reviewer when your work is _done and ready to be reviewed for merge_.
- [x] Tag others as Reviewers as necessary.
- [x] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

</details>